### PR TITLE
fix: the profile paths of the includes for packaging aws test jar fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,10 +230,10 @@
                                     <classesDirectory>${project.build.directory}/test-classes</classesDirectory>
                                     <classifier>tests</classifier>
                                     <includes>
-                                        <include>io.github.roberto22palomar/pepenium/core/**/*.class</include>
-                                        <include>io.github.roberto22palomar/pepenium/tests/myProject/aws/android/*Test.class</include>
-                                        <include>io.github.roberto22palomar/pepenium/toolkit/myProject/**/*.class</include>
-                                        <include>io.github.roberto22palomar/pepenium/toolkit/utils/**/*.class</include>
+                                        <include>io/github/roberto22palomar/pepenium/core/**/*.class</include>
+                                        <include>io/github/roberto22palomar/pepenium/tests/myProjectExample/aws/android/*Test.class</include>
+                                        <include>io/github/roberto22palomar/pepenium/toolkit/myProjectExample/**/*.class</include>
+                                        <include>io/github/roberto22palomar/pepenium/toolkit/utils/**/*.class</include>
                                     </includes>
                                     <archive>
                                         <manifest>


### PR DESCRIPTION
Fix of the includes paths from profiles that managed to generate de test-jar to upload aws device farm package 
Closes #27  