### PR TITLE
Prepare 0.9.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.5] - 2026-04-06
+
 ### Fixed
 - Made annotation-first injection compatible with manual lifecycle setups by deferring strict driver-bound wiring until after user-managed setup has had a chance to initialize the session.
 - Made annotation-first component creation deterministic when multiple constructors exist by requiring an explicit `@PepeniumInject` constructor.
+- Fixed toolkit helper injection for Selenium web runs so `ActionsWeb` and similar helpers resolve correctly when the active driver is a concrete `WebDriver` subclass such as `ChromeDriver`.
 - Reduced Maven Central release fragility by stopping the release profile from waiting for full `published` state before returning control to CI.
 
 ## [0.9.4] - 2026-04-01

--- a/README.es.md
+++ b/README.es.md
@@ -82,7 +82,7 @@ Dependencia tipica de consumo:
 <dependency>
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-toolkit</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Typical consumer dependency:
 <dependency>
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-toolkit</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
 </dependency>
 ```
 

--- a/consumer-smoke/README.md
+++ b/consumer-smoke/README.md
@@ -21,7 +21,7 @@ mvn -q -f consumer-smoke/pom.xml clean test-compile
 If needed, the consumed version can be overridden:
 
 ```bash
-mvn -q -f consumer-smoke/pom.xml clean test-compile -Dpepenium.version=0.9.4
+mvn -q -f consumer-smoke/pom.xml clean test-compile -Dpepenium.version=0.9.5
 ```
 
 ## What It Covers

--- a/consumer-smoke/pom.xml
+++ b/consumer-smoke/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <pepenium.version>0.9.4</pepenium.version>
+        <pepenium.version>0.9.5</pepenium.version>
         <junit.jupiter.version>5.13.1</junit.jupiter.version>
     </properties>
 

--- a/pepenium-core/pom.xml
+++ b/pepenium-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.4</version>
+        <version>0.9.5</version>
     </parent>
 
     <artifactId>pepenium</artifactId>

--- a/pepenium-examples/pom.xml
+++ b/pepenium-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.4</version>
+        <version>0.9.5</version>
     </parent>
 
     <artifactId>pepenium-examples</artifactId>

--- a/pepenium-toolkit/pom.xml
+++ b/pepenium-toolkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.4</version>
+        <version>0.9.5</version>
     </parent>
 
     <artifactId>pepenium-toolkit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-parent</artifactId>
-    <version>0.9.4</version>
+    <version>0.9.5</version>
     <packaging>pom</packaging>
     <name>Pepenium</name>
     <description>Java automation framework for Android, iOS and Web built on Appium, Selenium and JUnit 5.</description>
@@ -70,7 +70,7 @@
         <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
         <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
         <japicmp.maven.plugin.version>0.25.4</japicmp.maven.plugin.version>
-        <public.api.compatibility.baseline.version>0.9.3</public.api.compatibility.baseline.version>
+        <public.api.compatibility.baseline.version>0.9.4</public.api.compatibility.baseline.version>
         <spotbugs.maven.plugin.version>4.8.6.6</spotbugs.maven.plugin.version>
         <checkstyle.version>10.18.2</checkstyle.version>
         <central.publishing.maven.plugin.version>0.9.0</central.publishing.maven.plugin.version>


### PR DESCRIPTION
## Summary

- Bumps Pepenium from `0.9.4` to `0.9.5`
- Rolls the pending runtime/release hardening into a public patch release
- Updates public version references and moves the current `Unreleased` fixes into the `0.9.5` changelog entry

## What is included in 0.9.5

- annotation-first injection now behaves correctly with manual lifecycle setups
- constructor selection is explicit and deterministic when multiple injectable constructors exist
- web toolkit helpers now resolve correctly when Selenium uses concrete `WebDriver` subclasses such as `ChromeDriver`
- release publishing no longer waits for the full Sonatype `published` state before returning control to CI

## Validation

- `mvn -B -ntp verify`
- `mvn -B -ntp -pl pepenium-core "-Dtest=PepeniumAnnotationContractTest,PepeniumInjectionSupportTest,PepeniumLifecycleExtensionTest" test`
- `mvn -B -ntp -pl pepenium-core,pepenium-toolkit -am -DskipTests compile`
- `powershell -ExecutionPolicy Bypass -File .github\scripts\Test-ReleasePreflight.ps1 -ReleaseVersion 0.9.5`
- `mvn -B -ntp -Prelease verify -DskipTests "-Dgpg.skip=true" "-Dcentral.skipPublishing=true"`
- `mvn -B -ntp -pl pepenium-core,pepenium-toolkit -am install -DskipTests "-Djacoco.skip=true" "-Dcheckstyle.skip=true" "-Dspotbugs.skip=true" "-Djapicmp.skip=true"`
- `mvn -B -ntp -f consumer-smoke/pom.xml clean test-compile "-Dpepenium.version=0.9.5"`
