### PR TITLE
Prepare 0.9.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added optional `APPIUM_*` and `APP_WAIT_*` overrides for the Appium-backed built-in mobile native and mobile web profiles so advanced capabilities can be tuned from environment variables without overriding framework classes.
+
 ## [0.9.5] - 2026-04-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.6] - 2026-04-07
+
 ### Added
 - Added optional `APPIUM_*` and `APP_WAIT_*` overrides for the Appium-backed built-in mobile native and mobile web profiles so advanced capabilities can be tuned from environment variables without overriding framework classes.
 

--- a/README.es.md
+++ b/README.es.md
@@ -82,7 +82,7 @@ Dependencia tipica de consumo:
 <dependency>
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-toolkit</artifactId>
-    <version>0.9.5</version>
+    <version>0.9.6</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Typical consumer dependency:
 <dependency>
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-toolkit</artifactId>
-    <version>0.9.5</version>
+    <version>0.9.6</version>
 </dependency>
 ```
 

--- a/consumer-smoke/README.md
+++ b/consumer-smoke/README.md
@@ -21,7 +21,7 @@ mvn -q -f consumer-smoke/pom.xml clean test-compile
 If needed, the consumed version can be overridden:
 
 ```bash
-mvn -q -f consumer-smoke/pom.xml clean test-compile -Dpepenium.version=0.9.5
+mvn -q -f consumer-smoke/pom.xml clean test-compile -Dpepenium.version=0.9.6
 ```
 
 ## What It Covers

--- a/consumer-smoke/pom.xml
+++ b/consumer-smoke/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <pepenium.version>0.9.5</pepenium.version>
+        <pepenium.version>0.9.6</pepenium.version>
         <junit.jupiter.version>5.13.1</junit.jupiter.version>
     </properties>
 

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -94,7 +94,40 @@ PEPENIUM_PROFILE=local-web
 - Used by:
   - local Android native
 - Purpose: Android activity to launch together with `APP_PACKAGE`
+### Optional Appium capability overrides
 
+These optional environment variables are supported by the Appium-backed built-in profiles:
+
+- local Android native
+- local Android web
+- AWS Android native
+- AWS Android web
+- AWS iOS native
+- BrowserStack Android native
+- BrowserStack Android web
+- BrowserStack iOS native
+- BrowserStack iOS web
+
+- `APPIUM_PLATFORM_NAME`
+- `APPIUM_AUTOMATION_NAME`
+- `APPIUM_PLATFORM_VERSION`
+- `APPIUM_NEW_COMMAND_TIMEOUT`
+- `APPIUM_AUTO_GRANT_PERMISSIONS`
+- `APPIUM_NO_RESET`
+- `APPIUM_FULL_RESET`
+- `APPIUM_DONT_STOP_APP_ON_RESET`
+- `APPIUM_SKIP_DEVICE_INITIALIZATION`
+- `APPIUM_SKIP_SERVER_INSTALLATION`
+- `APPIUM_IGNORE_HIDDEN_API_POLICY_ERROR`
+- `APPIUM_AUTO_LAUNCH`
+- `APPIUM_ADB_EXEC_TIMEOUT`
+- `APPIUM_UIAUTOMATOR2_SERVER_LAUNCH_TIMEOUT`
+- `APPIUM_UIAUTOMATOR2_SERVER_INSTALL_TIMEOUT`
+- `APPIUM_ANDROID_INSTALL_TIMEOUT`
+- `APP_WAIT_PACKAGE`
+- `APP_WAIT_ACTIVITY`
+
+They are intended for advanced mobile runs when the default Appium option sets need to be tuned without forking the framework.
 ## Local Web and Mobile Web
 
 ### `PEPENIUM_BASE_URL`

--- a/pepenium-core/pom.xml
+++ b/pepenium-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.5</version>
+        <version>0.9.6</version>
     </parent>
 
     <artifactId>pepenium</artifactId>

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/config/validation/AppiumCapabilityOverrides.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/config/validation/AppiumCapabilityOverrides.java
@@ -1,0 +1,142 @@
+package io.github.roberto22palomar.pepenium.core.config.validation;
+
+import io.appium.java_client.android.options.UiAutomator2Options;
+import io.appium.java_client.ios.options.XCUITestOptions;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+public final class AppiumCapabilityOverrides {
+
+    private AppiumCapabilityOverrides() {
+    }
+
+    public static void applyAndroid(Function<String, String> env, UiAutomator2Options options) {
+        applyString(env, "APPIUM_PLATFORM_NAME", options::setPlatformName);
+        applyString(env, "APPIUM_AUTOMATION_NAME", options::setAutomationName);
+        applyString(env, "APPIUM_PLATFORM_VERSION", options::setPlatformVersion);
+        applyDurationSeconds(env, "APPIUM_NEW_COMMAND_TIMEOUT", options::setNewCommandTimeout);
+        applyBoolean(env, "APPIUM_AUTO_GRANT_PERMISSIONS",
+                value -> options.setCapability("appium:autoGrantPermissions", value));
+        applyBoolean(env, "APPIUM_NO_RESET", options::setNoReset);
+        applyBoolean(env, "APPIUM_FULL_RESET", options::setFullReset);
+        applyBooleanCapability(env, options, "APPIUM_DONT_STOP_APP_ON_RESET", "appium:dontStopAppOnReset");
+        applyBooleanCapability(env, options, "APPIUM_SKIP_DEVICE_INITIALIZATION", "appium:skipDeviceInitialization");
+        applyBooleanCapability(env, options, "APPIUM_SKIP_SERVER_INSTALLATION", "appium:skipServerInstallation");
+        applyBooleanCapability(env, options, "APPIUM_IGNORE_HIDDEN_API_POLICY_ERROR", "appium:ignoreHiddenApiPolicyError");
+        applyBooleanCapability(env, options, "APPIUM_AUTO_LAUNCH", "appium:autoLaunch");
+        applyLongCapability(env, options, "APPIUM_ADB_EXEC_TIMEOUT", "appium:adbExecTimeout");
+        applyLongCapability(env, options, "APPIUM_UIAUTOMATOR2_SERVER_LAUNCH_TIMEOUT",
+                "appium:uiautomator2ServerLaunchTimeout");
+        applyLongCapability(env, options, "APPIUM_UIAUTOMATOR2_SERVER_INSTALL_TIMEOUT",
+                "appium:uiautomator2ServerInstallTimeout");
+        applyLongCapability(env, options, "APPIUM_ANDROID_INSTALL_TIMEOUT", "appium:androidInstallTimeout");
+        applyStringCapability(env, options, "APP_WAIT_PACKAGE", "appium:appWaitPackage");
+        applyStringCapability(env, options, "APP_WAIT_ACTIVITY", "appium:appWaitActivity");
+    }
+
+    public static void applyIos(Function<String, String> env, XCUITestOptions options) {
+        applyString(env, "APPIUM_PLATFORM_NAME", options::setPlatformName);
+        applyString(env, "APPIUM_AUTOMATION_NAME", options::setAutomationName);
+        applyString(env, "APPIUM_PLATFORM_VERSION", options::setPlatformVersion);
+        applyDurationSeconds(env, "APPIUM_NEW_COMMAND_TIMEOUT", options::setNewCommandTimeout);
+        applyBoolean(env, "APPIUM_NO_RESET", options::setNoReset);
+        applyBoolean(env, "APPIUM_FULL_RESET", options::setFullReset);
+        applyBoolean(env, "APPIUM_AUTO_ACCEPT_ALERTS", options::setAutoAcceptAlerts);
+        applyDurationSeconds(env, "APPIUM_WDA_LAUNCH_TIMEOUT", options::setWdaLaunchTimeout);
+        applyDurationSeconds(env, "APPIUM_WDA_CONNECTION_TIMEOUT", options::setWdaConnectionTimeout);
+        applyBooleanCapability(env, options, "APPIUM_AUTO_LAUNCH", "appium:autoLaunch");
+    }
+
+    private static void applyString(Function<String, String> env, String key, java.util.function.Consumer<String> setter) {
+        String value = envValue(env, key);
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+
+    private static void applyDurationSeconds(Function<String, String> env,
+                                             String key,
+                                             java.util.function.Consumer<Duration> setter) {
+        String value = envValue(env, key);
+        if (value != null) {
+            setter.accept(Duration.ofSeconds(parseLong(key, value)));
+        }
+    }
+
+    private static void applyBoolean(Function<String, String> env,
+                                     String key,
+                                     java.util.function.Consumer<Boolean> setter) {
+        String value = envValue(env, key);
+        if (value != null) {
+            setter.accept(parseBoolean(key, value));
+        }
+    }
+
+    private static void applyStringCapability(Function<String, String> env,
+                                              Object options,
+                                              String envKey,
+                                              String capabilityName) {
+        String value = envValue(env, envKey);
+        if (value != null) {
+            if (options instanceof UiAutomator2Options) {
+                ((UiAutomator2Options) options).setCapability(capabilityName, value);
+            } else {
+                ((XCUITestOptions) options).setCapability(capabilityName, value);
+            }
+        }
+    }
+
+    private static void applyBooleanCapability(Function<String, String> env,
+                                               Object options,
+                                               String envKey,
+                                               String capabilityName) {
+        String value = envValue(env, envKey);
+        if (value != null) {
+            boolean parsed = parseBoolean(envKey, value);
+            if (options instanceof UiAutomator2Options) {
+                ((UiAutomator2Options) options).setCapability(capabilityName, parsed);
+            } else {
+                ((XCUITestOptions) options).setCapability(capabilityName, parsed);
+            }
+        }
+    }
+
+    private static void applyLongCapability(Function<String, String> env,
+                                            Object options,
+                                            String envKey,
+                                            String capabilityName) {
+        String value = envValue(env, envKey);
+        if (value != null) {
+            long parsed = parseLong(envKey, value);
+            if (options instanceof UiAutomator2Options) {
+                ((UiAutomator2Options) options).setCapability(capabilityName, parsed);
+            } else {
+                ((XCUITestOptions) options).setCapability(capabilityName, parsed);
+            }
+        }
+    }
+
+    private static String envValue(Function<String, String> env, String key) {
+        String value = env.apply(key);
+        return (value == null || value.isBlank()) ? null : value.trim();
+    }
+
+    private static long parseLong(String key, String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ex) {
+            throw new IllegalStateException(key + " must be a valid integer value.", ex);
+        }
+    }
+
+    private static boolean parseBoolean(String key, String value) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        throw new IllegalStateException(key + " must be either 'true' or 'false'.");
+    }
+}

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/aws/android/AndroidConfigAWS.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/aws/android/AndroidConfigAWS.java
@@ -3,6 +3,7 @@ package io.github.roberto22palomar.pepenium.core.configs.aws.android;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.config.validation.ConfigValidationSupport;
 import io.appium.java_client.android.options.UiAutomator2Options;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
@@ -63,6 +64,7 @@ public class AndroidConfigAWS implements DriverConfig {
                 .setNewCommandTimeout(Duration.ofSeconds(300))
                 .setAutoGrantPermissions(true)
                 .setNoReset(false);
+        AppiumCapabilityOverrides.applyAndroid(env, opts);
 
         return DriverRequest.builder()
                 .driverType(DriverType.ANDROID_APPIUM)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/aws/android/AndroidWebConfigAWS.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/aws/android/AndroidWebConfigAWS.java
@@ -3,6 +3,7 @@ package io.github.roberto22palomar.pepenium.core.configs.aws.android;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.config.validation.ConfigValidationSupport;
 import io.appium.java_client.android.options.UiAutomator2Options;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
@@ -55,6 +56,7 @@ public class AndroidWebConfigAWS implements DriverConfig {
                 .setAutomationName("UiAutomator2")
                 .setNewCommandTimeout(Duration.ofSeconds(300));
         opts.setCapability("browserName", "Chrome");
+        AppiumCapabilityOverrides.applyAndroid(env, opts);
 
         return DriverRequest.builder()
                 .driverType(DriverType.ANDROID_APPIUM)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/aws/ios/IOSConfigAWS.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/aws/ios/IOSConfigAWS.java
@@ -3,6 +3,7 @@ package io.github.roberto22palomar.pepenium.core.configs.aws.ios;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.config.validation.ConfigValidationSupport;
 import io.appium.java_client.ios.options.XCUITestOptions;
 import io.appium.java_client.service.local.AppiumDriverLocalService;
@@ -65,6 +66,7 @@ public class IOSConfigAWS implements DriverConfig {
                 .setWdaConnectionTimeout(Duration.ofSeconds(120))
                 .setAutoAcceptAlerts(true)
                 .setNoReset(false);
+        AppiumCapabilityOverrides.applyIos(env, opts);
 
         return DriverRequest.builder()
                 .driverType(DriverType.IOS_APPIUM)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/android/AndroidConfigBS.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/android/AndroidConfigBS.java
@@ -2,6 +2,7 @@ package io.github.roberto22palomar.pepenium.core.configs.browserstack.android;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.appium.java_client.android.options.UiAutomator2Options;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -14,6 +15,7 @@ import org.openqa.selenium.MutableCapabilities;
 import java.net.URL;
 import java.time.Duration;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class AndroidConfigBS implements DriverConfig {
@@ -22,13 +24,14 @@ public class AndroidConfigBS implements DriverConfig {
 
     private final BrowserStackConfig config;
     private final BrowserStackConfig.Platform platform;
+    private final Function<String, String> env;
 
     @SuppressFBWarnings(
             value = "CT_CONSTRUCTOR_THROW",
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
     public AndroidConfigBS() {
-        this(loadConfig(), null);
+        this(loadConfig(), null, System::getenv);
     }
 
     @SuppressFBWarnings(
@@ -36,16 +39,17 @@ public class AndroidConfigBS implements DriverConfig {
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
     public AndroidConfigBS(BrowserStackConfig.Platform platform) {
-        this(loadConfig(), platform);
+        this(loadConfig(), platform, System::getenv);
     }
 
     @SuppressFBWarnings(
             value = "CT_CONSTRUCTOR_THROW",
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
-    private AndroidConfigBS(BrowserStackConfig config, BrowserStackConfig.Platform platform) {
+    AndroidConfigBS(BrowserStackConfig config, BrowserStackConfig.Platform platform, Function<String, String> env) {
         this.config = config;
         this.platform = platform != null ? platform : getDefaultPlatform(config);
+        this.env = env;
     }
 
     public static Stream<Arguments> platforms() {
@@ -62,6 +66,7 @@ public class AndroidConfigBS implements DriverConfig {
                 .setPlatformVersion(platform.getPlatformVersion())
                 .setApp(config.getApp())
                 .setNewCommandTimeout(Duration.ofSeconds(300));
+        AppiumCapabilityOverrides.applyAndroid(env, opts);
 
         MutableCapabilities bstackOptions = new MutableCapabilities();
         bstackOptions.setCapability("appProfiling", true);

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/android/AndroidWebConfigBS.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/android/AndroidWebConfigBS.java
@@ -1,10 +1,12 @@
 package io.github.roberto22palomar.pepenium.core.configs.browserstack.android;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.appium.java_client.android.options.UiAutomator2Options;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
 import io.github.roberto22palomar.pepenium.core.config.browserstack.BrowserStackConfigMobile;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.config.yaml.YamlLoaderMobile;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.provider.Arguments;
@@ -12,6 +14,7 @@ import org.openqa.selenium.MutableCapabilities;
 
 import java.net.URL;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class AndroidWebConfigBS implements DriverConfig {
@@ -20,13 +23,14 @@ public class AndroidWebConfigBS implements DriverConfig {
 
     private final BrowserStackConfigMobile config;
     private final BrowserStackConfigMobile.Platform platform;
+    private final Function<String, String> env;
 
     @SuppressFBWarnings(
             value = "CT_CONSTRUCTOR_THROW",
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
     public AndroidWebConfigBS() {
-        this(loadConfig(), null);
+        this(loadConfig(), null, System::getenv);
     }
 
     @SuppressFBWarnings(
@@ -34,16 +38,19 @@ public class AndroidWebConfigBS implements DriverConfig {
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
     public AndroidWebConfigBS(BrowserStackConfigMobile.Platform platform) {
-        this(loadConfig(), platform);
+        this(loadConfig(), platform, System::getenv);
     }
 
     @SuppressFBWarnings(
             value = "CT_CONSTRUCTOR_THROW",
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
-    private AndroidWebConfigBS(BrowserStackConfigMobile config, BrowserStackConfigMobile.Platform platform) {
+    AndroidWebConfigBS(BrowserStackConfigMobile config,
+                       BrowserStackConfigMobile.Platform platform,
+                       Function<String, String> env) {
         this.config = config;
         this.platform = platform != null ? platform : getDefaultPlatform(config);
+        this.env = env;
     }
 
     public static Stream<Arguments> platforms() {
@@ -53,9 +60,11 @@ public class AndroidWebConfigBS implements DriverConfig {
 
     @Override
     public DriverRequest createRequest() throws Exception {
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("platformName", "Android");
+        UiAutomator2Options caps = new UiAutomator2Options()
+                .setPlatformName("Android")
+                .setAutomationName("UiAutomator2");
         caps.setCapability("browserName", "Chrome");
+        AppiumCapabilityOverrides.applyAndroid(env, caps);
 
         MutableCapabilities bstackOptions = new MutableCapabilities();
         bstackOptions.setCapability("deviceName", platform.getDeviceName());

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/ios/IOSConfigBS.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/ios/IOSConfigBS.java
@@ -2,6 +2,7 @@ package io.github.roberto22palomar.pepenium.core.configs.browserstack.ios;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.appium.java_client.ios.options.XCUITestOptions;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -14,6 +15,7 @@ import org.openqa.selenium.MutableCapabilities;
 import java.net.URL;
 import java.time.Duration;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class IOSConfigBS implements DriverConfig {
@@ -22,13 +24,14 @@ public class IOSConfigBS implements DriverConfig {
 
     private final BrowserStackConfig config;
     private final BrowserStackConfig.Platform platform;
+    private final Function<String, String> env;
 
     @SuppressFBWarnings(
             value = "CT_CONSTRUCTOR_THROW",
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
     public IOSConfigBS() {
-        this(loadConfig(), null);
+        this(loadConfig(), null, System::getenv);
     }
 
     @SuppressFBWarnings(
@@ -36,16 +39,17 @@ public class IOSConfigBS implements DriverConfig {
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
     public IOSConfigBS(BrowserStackConfig.Platform platform) {
-        this(loadConfig(), platform);
+        this(loadConfig(), platform, System::getenv);
     }
 
     @SuppressFBWarnings(
             value = "CT_CONSTRUCTOR_THROW",
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
-    private IOSConfigBS(BrowserStackConfig config, BrowserStackConfig.Platform platform) {
+    IOSConfigBS(BrowserStackConfig config, BrowserStackConfig.Platform platform, Function<String, String> env) {
         this.config = config;
         this.platform = platform != null ? platform : getDefaultPlatform(config);
+        this.env = env;
     }
 
     public static Stream<Arguments> platforms() {
@@ -61,6 +65,7 @@ public class IOSConfigBS implements DriverConfig {
                 .setPlatformVersion(platform.getPlatformVersion())
                 .setApp(config.getApp())
                 .setNewCommandTimeout(Duration.ofSeconds(300));
+        AppiumCapabilityOverrides.applyIos(env, opts);
 
         MutableCapabilities bstackOptions = new MutableCapabilities();
         bstackOptions.setCapability("appProfiling", true);

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/ios/IOSWebConfigBS.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/ios/IOSWebConfigBS.java
@@ -1,10 +1,12 @@
 package io.github.roberto22palomar.pepenium.core.configs.browserstack.ios;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.appium.java_client.ios.options.XCUITestOptions;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
 import io.github.roberto22palomar.pepenium.core.config.browserstack.BrowserStackConfigMobile;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.config.yaml.YamlLoaderMobile;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.provider.Arguments;
@@ -12,6 +14,7 @@ import org.openqa.selenium.MutableCapabilities;
 
 import java.net.URL;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public class IOSWebConfigBS implements DriverConfig {
@@ -20,13 +23,14 @@ public class IOSWebConfigBS implements DriverConfig {
 
     private final BrowserStackConfigMobile config;
     private final BrowserStackConfigMobile.Platform platform;
+    private final Function<String, String> env;
 
     @SuppressFBWarnings(
             value = "CT_CONSTRUCTOR_THROW",
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
     public IOSWebConfigBS() {
-        this(loadConfig(), null);
+        this(loadConfig(), null, System::getenv);
     }
 
     @SuppressFBWarnings(
@@ -34,16 +38,19 @@ public class IOSWebConfigBS implements DriverConfig {
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
     public IOSWebConfigBS(BrowserStackConfigMobile.Platform platform) {
-        this(loadConfig(), platform);
+        this(loadConfig(), platform, System::getenv);
     }
 
     @SuppressFBWarnings(
             value = "CT_CONSTRUCTOR_THROW",
             justification = "Constructors validate remote provider configuration eagerly for invalid YAML."
     )
-    private IOSWebConfigBS(BrowserStackConfigMobile config, BrowserStackConfigMobile.Platform platform) {
+    IOSWebConfigBS(BrowserStackConfigMobile config,
+                   BrowserStackConfigMobile.Platform platform,
+                   Function<String, String> env) {
         this.config = config;
         this.platform = platform != null ? platform : getDefaultPlatform(config);
+        this.env = env;
     }
 
     public static Stream<Arguments> platforms() {
@@ -53,9 +60,11 @@ public class IOSWebConfigBS implements DriverConfig {
 
     @Override
     public DriverRequest createRequest() throws Exception {
-        MutableCapabilities caps = new MutableCapabilities();
-        caps.setCapability("platformName", "iOS");
+        XCUITestOptions caps = new XCUITestOptions()
+                .setPlatformName("iOS")
+                .setAutomationName("XCUITest");
         caps.setCapability("browserName", "Safari");
+        AppiumCapabilityOverrides.applyIos(env, caps);
 
         MutableCapabilities bstackOptions = new MutableCapabilities();
         bstackOptions.setCapability("deviceName", platform.getDeviceName());

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/android/AndroidConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/android/AndroidConfigLocal.java
@@ -2,6 +2,7 @@ package io.github.roberto22palomar.pepenium.core.configs.local.android;
 
 import io.appium.java_client.android.options.UiAutomator2Options;
 import io.github.roberto22palomar.pepenium.core.config.validation.ConfigValidationSupport;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -59,6 +60,7 @@ public class AndroidConfigLocal implements DriverConfig {
             opts.setAppActivity(appActivity);
         }
 
+        AppiumCapabilityOverrides.applyAndroid(env, opts);
         ConfigValidationSupport.requireAtLeastOneFilled(
                 "Local Android native app configuration",
                 Arrays.asList(appPath, appPackage),
@@ -81,8 +83,13 @@ public class AndroidConfigLocal implements DriverConfig {
     }
 
     private String envOrDefault(String key, String defaultValue) {
+        String value = envValue(key);
+        return value == null ? defaultValue : value;
+    }
+
+    private String envValue(String key) {
         String value = env.apply(key);
-        return (value == null || value.isBlank()) ? defaultValue : value.trim();
+        return (value == null || value.isBlank()) ? null : value.trim();
     }
 
     private static boolean notBlank(String value) {

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/android/AndroidWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/android/AndroidWebConfigLocal.java
@@ -1,6 +1,7 @@
 package io.github.roberto22palomar.pepenium.core.configs.local.android;
 
 import io.appium.java_client.android.options.UiAutomator2Options;
+import io.github.roberto22palomar.pepenium.core.config.validation.AppiumCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.config.validation.ConfigValidationSupport;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
@@ -39,6 +40,7 @@ public class AndroidWebConfigLocal implements DriverConfig {
                 .setUdid(udid)
                 .setNewCommandTimeout(Duration.ofSeconds(300));
         opts.setCapability("browserName", "Chrome");
+        AppiumCapabilityOverrides.applyAndroid(env, opts);
 
         return DriverRequest.builder()
                 .driverType(DriverType.ANDROID_APPIUM)

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/aws/android/AndroidAwsConfigTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/aws/android/AndroidAwsConfigTest.java
@@ -62,6 +62,24 @@ class AndroidAwsConfigTest {
     }
 
     @Test
+    void createAndroidNativeRequestAppliesAppiumOverrides() throws Exception {
+        AppiumServiceBuilder builder = mockBuilder();
+        AppiumDriverLocalService service = mockService("http://127.0.0.1:49004");
+        when(builder.build()).thenReturn(service);
+        AndroidConfigAWS config = new AndroidConfigAWS(env(Map.ofEntries(
+                Map.entry("APPIUM_NO_RESET", "true"),
+                Map.entry("APPIUM_FULL_RESET", "true"),
+                Map.entry("APP_WAIT_ACTIVITY", ".SplashActivity")
+        )), () -> builder);
+
+        DriverRequest request = config.createRequest();
+
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:noReset"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:fullReset"));
+        assertEquals(".SplashActivity", request.getCapabilities().getCapability("appium:appWaitActivity"));
+    }
+
+    @Test
     void createAndroidNativeDeviceFarmRequestRejectsMissingAppPath() {
         AndroidConfigAWS config = new AndroidConfigAWS(
                 env(Map.of(
@@ -105,6 +123,22 @@ class AndroidAwsConfigTest {
         assertNull(request.getOwnedService());
         assertEquals("Galaxy Web", request.getCapabilities().getCapability("appium:deviceName"));
         assertEquals("Chrome", request.getCapabilities().getCapability("browserName"));
+    }
+
+    @Test
+    void createAndroidWebRequestAppliesAppiumOverrides() throws Exception {
+        AppiumServiceBuilder builder = mockBuilder();
+        AppiumDriverLocalService service = mockService("http://127.0.0.1:49005");
+        when(builder.build()).thenReturn(service);
+        AndroidWebConfigAWS config = new AndroidWebConfigAWS(env(Map.ofEntries(
+                Map.entry("APPIUM_NEW_COMMAND_TIMEOUT", "120"),
+                Map.entry("APPIUM_SKIP_DEVICE_INITIALIZATION", "true")
+        )), () -> builder);
+
+        DriverRequest request = config.createRequest();
+
+        assertEquals(120L, request.getCapabilities().getCapability("appium:newCommandTimeout"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:skipDeviceInitialization"));
     }
 
     @Test

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/aws/ios/IOSAwsConfigTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/aws/ios/IOSAwsConfigTest.java
@@ -64,6 +64,25 @@ class IOSAwsConfigTest {
     }
 
     @Test
+    void createIosRequestAppliesAppiumOverrides() throws Exception {
+        AppiumServiceBuilder builder = mockBuilder();
+        AppiumDriverLocalService service = mockService("http://127.0.0.1:49006");
+        when(builder.build()).thenReturn(service);
+        IOSConfigAWS config = new IOSConfigAWS(env(Map.ofEntries(
+                Map.entry("APPIUM_NEW_COMMAND_TIMEOUT", "180"),
+                Map.entry("APPIUM_AUTO_ACCEPT_ALERTS", "false"),
+                Map.entry("APPIUM_WDA_CONNECTION_TIMEOUT", "60")
+        )), () -> builder);
+
+        DriverRequest request = config.createRequest();
+
+        assertEquals(180L, request.getCapabilities().getCapability("appium:newCommandTimeout"));
+        assertEquals(Boolean.FALSE, request.getCapabilities().getCapability("appium:autoAcceptAlerts"));
+        assertEquals(60000L, request.getCapabilities().getCapability("appium:wdaConnectionTimeout"));
+        assertSame(service, request.getOwnedService());
+    }
+
+    @Test
     void createIosDeviceFarmRequestRejectsMissingAppPath() {
         IOSConfigAWS config = new IOSConfigAWS(
                 env(Map.of(

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/android/AndroidBrowserStackConfigTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/android/AndroidBrowserStackConfigTest.java
@@ -1,0 +1,69 @@
+package io.github.roberto22palomar.pepenium.core.configs.browserstack.android;
+
+import io.github.roberto22palomar.pepenium.core.config.browserstack.BrowserStackConfig;
+import io.github.roberto22palomar.pepenium.core.config.browserstack.BrowserStackConfigMobile;
+import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AndroidBrowserStackConfigTest {
+
+    @Test
+    void createRequestAppliesAndroidAppiumOverrides() throws Exception {
+        BrowserStackConfig config = BrowserStackConfig.builder()
+                .userName("user")
+                .accessKey("key")
+                .app("bs://app")
+                .projectName("project")
+                .buildName("build")
+                .platforms(List.of())
+                .build();
+        BrowserStackConfig.Platform platform = BrowserStackConfig.Platform.builder()
+                .platformName("android")
+                .deviceName("Pixel 9")
+                .platformVersion("15")
+                .build();
+
+        AndroidConfigBS driverConfig = new AndroidConfigBS(config, platform, Map.of(
+                "APPIUM_NEW_COMMAND_TIMEOUT", "120",
+                "APPIUM_AUTO_GRANT_PERMISSIONS", "false",
+                "APP_WAIT_ACTIVITY", ".SplashActivity"
+        )::get);
+
+        DriverRequest request = driverConfig.createRequest();
+
+        assertEquals(120L, request.getCapabilities().getCapability("appium:newCommandTimeout"));
+        assertEquals(Boolean.FALSE, request.getCapabilities().getCapability("appium:autoGrantPermissions"));
+        assertEquals(".SplashActivity", request.getCapabilities().getCapability("appium:appWaitActivity"));
+    }
+
+    @Test
+    void createWebRequestAppliesAndroidAppiumOverrides() throws Exception {
+        BrowserStackConfigMobile config = BrowserStackConfigMobile.builder()
+                .userName("user")
+                .accessKey("key")
+                .projectName("project")
+                .buildName("build")
+                .platforms(List.of())
+                .build();
+        BrowserStackConfigMobile.Platform platform = BrowserStackConfigMobile.Platform.builder()
+                .deviceName("Pixel 9")
+                .osVersion("15")
+                .browserName("Chrome")
+                .build();
+
+        AndroidWebConfigBS driverConfig = new AndroidWebConfigBS(config, platform, Map.of(
+                "APPIUM_NEW_COMMAND_TIMEOUT", "90",
+                "APPIUM_SKIP_DEVICE_INITIALIZATION", "true"
+        )::get);
+
+        DriverRequest request = driverConfig.createRequest();
+
+        assertEquals(90L, request.getCapabilities().getCapability("appium:newCommandTimeout"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:skipDeviceInitialization"));
+    }
+}

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/ios/IOSBrowserStackConfigTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/browserstack/ios/IOSBrowserStackConfigTest.java
@@ -1,0 +1,69 @@
+package io.github.roberto22palomar.pepenium.core.configs.browserstack.ios;
+
+import io.github.roberto22palomar.pepenium.core.config.browserstack.BrowserStackConfig;
+import io.github.roberto22palomar.pepenium.core.config.browserstack.BrowserStackConfigMobile;
+import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IOSBrowserStackConfigTest {
+
+    @Test
+    void createRequestAppliesIosAppiumOverrides() throws Exception {
+        BrowserStackConfig config = BrowserStackConfig.builder()
+                .userName("user")
+                .accessKey("key")
+                .app("bs://app")
+                .projectName("project")
+                .buildName("build")
+                .platforms(List.of())
+                .build();
+        BrowserStackConfig.Platform platform = BrowserStackConfig.Platform.builder()
+                .platformName("ios")
+                .deviceName("iPhone 16")
+                .platformVersion("18")
+                .build();
+
+        IOSConfigBS driverConfig = new IOSConfigBS(config, platform, Map.of(
+                "APPIUM_NEW_COMMAND_TIMEOUT", "180",
+                "APPIUM_AUTO_ACCEPT_ALERTS", "false",
+                "APPIUM_WDA_LAUNCH_TIMEOUT", "60"
+        )::get);
+
+        DriverRequest request = driverConfig.createRequest();
+
+        assertEquals(180L, request.getCapabilities().getCapability("appium:newCommandTimeout"));
+        assertEquals(Boolean.FALSE, request.getCapabilities().getCapability("appium:autoAcceptAlerts"));
+        assertEquals(60000L, request.getCapabilities().getCapability("appium:wdaLaunchTimeout"));
+    }
+
+    @Test
+    void createWebRequestAppliesIosAppiumOverrides() throws Exception {
+        BrowserStackConfigMobile config = BrowserStackConfigMobile.builder()
+                .userName("user")
+                .accessKey("key")
+                .projectName("project")
+                .buildName("build")
+                .platforms(List.of())
+                .build();
+        BrowserStackConfigMobile.Platform platform = BrowserStackConfigMobile.Platform.builder()
+                .deviceName("iPhone 16")
+                .osVersion("18")
+                .browserName("Safari")
+                .build();
+
+        IOSWebConfigBS driverConfig = new IOSWebConfigBS(config, platform, Map.of(
+                "APPIUM_NEW_COMMAND_TIMEOUT", "150",
+                "APPIUM_AUTO_ACCEPT_ALERTS", "false"
+        )::get);
+
+        DriverRequest request = driverConfig.createRequest();
+
+        assertEquals(150L, request.getCapabilities().getCapability("appium:newCommandTimeout"));
+        assertEquals(Boolean.FALSE, request.getCapabilities().getCapability("appium:autoAcceptAlerts"));
+    }
+}

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/local/android/AndroidLocalConfigTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/configs/local/android/AndroidLocalConfigTest.java
@@ -59,6 +59,78 @@ class AndroidLocalConfigTest {
     }
 
     @Test
+    void createAndroidNativeRequestAppliesOptionalAppiumCapabilityOverrides() throws Exception {
+        AndroidConfigLocal config = new AndroidConfigLocal(env(Map.ofEntries(
+                Map.entry("APP_PACKAGE", "io.github.example"),
+                Map.entry("APP_ACTIVITY", ".MainActivity"),
+                Map.entry("APPIUM_PLATFORM_NAME", "Android"),
+                Map.entry("APPIUM_AUTOMATION_NAME", "UiAutomator2"),
+                Map.entry("APPIUM_PLATFORM_VERSION", "15"),
+                Map.entry("APPIUM_NEW_COMMAND_TIMEOUT", "120"),
+                Map.entry("APPIUM_AUTO_GRANT_PERMISSIONS", "false"),
+                Map.entry("APPIUM_NO_RESET", "true"),
+                Map.entry("APPIUM_FULL_RESET", "true"),
+                Map.entry("APPIUM_DONT_STOP_APP_ON_RESET", "true"),
+                Map.entry("APPIUM_SKIP_DEVICE_INITIALIZATION", "true"),
+                Map.entry("APPIUM_SKIP_SERVER_INSTALLATION", "true"),
+                Map.entry("APPIUM_IGNORE_HIDDEN_API_POLICY_ERROR", "true"),
+                Map.entry("APPIUM_AUTO_LAUNCH", "false"),
+                Map.entry("APPIUM_ADB_EXEC_TIMEOUT", "45000"),
+                Map.entry("APPIUM_UIAUTOMATOR2_SERVER_LAUNCH_TIMEOUT", "90000"),
+                Map.entry("APPIUM_UIAUTOMATOR2_SERVER_INSTALL_TIMEOUT", "91000"),
+                Map.entry("APPIUM_ANDROID_INSTALL_TIMEOUT", "92000"),
+                Map.entry("APP_WAIT_PACKAGE", "io.github.example"),
+                Map.entry("APP_WAIT_ACTIVITY", ".SplashActivity")
+        )));
+
+        DriverRequest request = config.createRequest();
+
+        assertEquals("15", request.getCapabilities().getCapability("appium:platformVersion"));
+        assertEquals("UiAutomator2", request.getCapabilities().getCapability("appium:automationName"));
+        assertEquals(120L, request.getCapabilities().getCapability("appium:newCommandTimeout"));
+        assertEquals(Boolean.FALSE, request.getCapabilities().getCapability("appium:autoGrantPermissions"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:noReset"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:fullReset"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:dontStopAppOnReset"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:skipDeviceInitialization"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:skipServerInstallation"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:ignoreHiddenApiPolicyError"));
+        assertEquals(Boolean.FALSE, request.getCapabilities().getCapability("appium:autoLaunch"));
+        assertEquals(45000L, request.getCapabilities().getCapability("appium:adbExecTimeout"));
+        assertEquals(90000L, request.getCapabilities().getCapability("appium:uiautomator2ServerLaunchTimeout"));
+        assertEquals(91000L, request.getCapabilities().getCapability("appium:uiautomator2ServerInstallTimeout"));
+        assertEquals(92000L, request.getCapabilities().getCapability("appium:androidInstallTimeout"));
+        assertEquals("io.github.example", request.getCapabilities().getCapability("appium:appWaitPackage"));
+        assertEquals(".SplashActivity", request.getCapabilities().getCapability("appium:appWaitActivity"));
+    }
+
+    @Test
+    void createAndroidNativeRequestRejectsInvalidBooleanOverride() {
+        AndroidConfigLocal config = new AndroidConfigLocal(env(Map.of(
+                "APP_PACKAGE", "io.github.example",
+                "APP_ACTIVITY", ".MainActivity",
+                "APPIUM_NO_RESET", "maybe"
+        )));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, config::createRequest);
+
+        assertTrue(exception.getMessage().contains("APPIUM_NO_RESET must be either 'true' or 'false'."));
+    }
+
+    @Test
+    void createAndroidNativeRequestRejectsInvalidNumericOverride() {
+        AndroidConfigLocal config = new AndroidConfigLocal(env(Map.of(
+                "APP_PACKAGE", "io.github.example",
+                "APP_ACTIVITY", ".MainActivity",
+                "APPIUM_NEW_COMMAND_TIMEOUT", "abc"
+        )));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, config::createRequest);
+
+        assertTrue(exception.getMessage().contains("APPIUM_NEW_COMMAND_TIMEOUT must be a valid integer value."));
+    }
+
+    @Test
     void createAndroidNativeRequestRejectsMissingAppConfiguration() {
         AndroidConfigLocal config = new AndroidConfigLocal(env(Map.of()));
 
@@ -91,6 +163,19 @@ class AndroidLocalConfigTest {
         assertEquals("Android Device", request.getCapabilities().getCapability("appium:deviceName"));
         assertEquals("emulator-5554", request.getCapabilities().getCapability("appium:udid"));
         assertEquals("Chrome", request.getCapabilities().getCapability("browserName"));
+    }
+
+    @Test
+    void createAndroidWebRequestAppliesAppiumOverrides() throws Exception {
+        AndroidWebConfigLocal config = new AndroidWebConfigLocal(env(Map.ofEntries(
+                Map.entry("APPIUM_NEW_COMMAND_TIMEOUT", "90"),
+                Map.entry("APPIUM_SKIP_DEVICE_INITIALIZATION", "true")
+        )));
+
+        DriverRequest request = config.createRequest();
+
+        assertEquals(90L, request.getCapabilities().getCapability("appium:newCommandTimeout"));
+        assertEquals(Boolean.TRUE, request.getCapabilities().getCapability("appium:skipDeviceInitialization"));
     }
 
     @Test

--- a/pepenium-examples/pom.xml
+++ b/pepenium-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.5</version>
+        <version>0.9.6</version>
     </parent>
 
     <artifactId>pepenium-examples</artifactId>

--- a/pepenium-toolkit/pom.xml
+++ b/pepenium-toolkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.5</version>
+        <version>0.9.6</version>
     </parent>
 
     <artifactId>pepenium-toolkit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-parent</artifactId>
-    <version>0.9.5</version>
+    <version>0.9.6</version>
     <packaging>pom</packaging>
     <name>Pepenium</name>
     <description>Java automation framework for Android, iOS and Web built on Appium, Selenium and JUnit 5.</description>
@@ -70,7 +70,7 @@
         <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
         <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
         <japicmp.maven.plugin.version>0.25.4</japicmp.maven.plugin.version>
-        <public.api.compatibility.baseline.version>0.9.4</public.api.compatibility.baseline.version>
+        <public.api.compatibility.baseline.version>0.9.5</public.api.compatibility.baseline.version>
         <spotbugs.maven.plugin.version>4.8.6.6</spotbugs.maven.plugin.version>
         <checkstyle.version>10.18.2</checkstyle.version>
         <central.publishing.maven.plugin.version>0.9.0</central.publishing.maven.plugin.version>


### PR DESCRIPTION
## Summary

- prepare the `0.9.6` release line
- ship Appium capability overrides across the built-in mobile native and mobile web profiles
- align release metadata, docs and consumer-smoke with `0.9.6`

## Type of Change

- [x] New feature
- [x] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD or workflow change
- [ ] Breaking change

## Validation

- [x] `mvn -B -ntp verify`
- [x] `powershell -ExecutionPolicy Bypass -File .github\scripts\Test-ReleasePreflight.ps1 -ReleaseVersion 0.9.6`
- [x] `mvn -B -ntp -Prelease verify -DskipTests "-Dgpg.skip=true" "-Dcentral.skipPublishing=true"`
- [x] `mvn -B -ntp -pl pepenium-core,pepenium-toolkit -am install -DskipTests "-Djacoco.skip=true" "-Dcheckstyle.skip=true" "-Dspotbugs.skip=true" "-Djapicmp.skip=true"`
- [x] `mvn -o -B -ntp -f consumer-smoke/pom.xml clean test-compile "-Dpepenium.version=0.9.6"`
- [x] Documentation updated when needed
- [x] Changelog updated when needed

## Notes for Reviewers

- `0.9.6` includes the broader follow-up to the initial local Android override work: local Android native/web, AWS Android native/web, AWS iOS native, BrowserStack Android/iOS native, and BrowserStack Android/iOS web now accept the documented `APPIUM_*` and `APP_WAIT_*` capability overrides.
- The release branch is based on `main` after `0.9.5`, so the API compatibility baseline is now pinned to `0.9.5`.
- The local PDF/HTML release-history files under `docs/` were intentionally left out.
