### PR TITLE
Improve driver session capability observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Improved driver-session observability by logging the effective sanitized capabilities sent to the driver layer and surfacing the same detail in automatic failure reporting.
+
 ## [0.9.5] - 2026-04-06
 
 ### Fixed

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/CapabilitiesSummary.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/CapabilitiesSummary.java
@@ -2,9 +2,11 @@ package io.github.roberto22palomar.pepenium.core.observability;
 
 import org.openqa.selenium.Capabilities;
 
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.TreeMap;
 
 public final class CapabilitiesSummary {
 
@@ -49,5 +51,42 @@ public final class CapabilitiesSummary {
         StringJoiner joiner = new StringJoiner(", ");
         selected.forEach((key, value) -> joiner.add(key + "=" + value));
         return joiner.toString();
+    }
+
+    public static String describe(Capabilities capabilities) {
+        if (capabilities == null) {
+            return "none";
+        }
+
+        Map<String, Object> all = capabilities.asMap();
+        if (all.isEmpty()) {
+            return "present";
+        }
+
+        Map<String, Object> ordered = new TreeMap<>(Comparator.naturalOrder());
+        all.forEach((key, value) -> ordered.put(key, sanitizeValue(key, value)));
+
+        StringJoiner joiner = new StringJoiner(", ");
+        ordered.forEach((key, value) -> joiner.add(key + "=" + value));
+        return joiner.toString();
+    }
+
+    private static Object sanitizeValue(String key, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (isSensitiveKey(key)) {
+            return "***";
+        }
+        return value;
+    }
+
+    private static boolean isSensitiveKey(String key) {
+        String normalized = key == null ? "" : key.toLowerCase();
+        return normalized.contains("accesskey")
+                || normalized.contains("password")
+                || normalized.contains("secret")
+                || normalized.contains("token")
+                || normalized.contains("apikey");
     }
 }

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporter.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporter.java
@@ -42,7 +42,8 @@ public final class FailureContextReporter {
                 request.getExecutionProfileId(),
                 request.getDriverType());
         logSteps();
-        log.error("Capabilities: {}", CapabilitiesSummary.summarize(request.getCapabilities()));
+        log.error("Capabilities summary: {}", CapabilitiesSummary.summarize(request.getCapabilities()));
+        log.error("Effective capabilities: {}", CapabilitiesSummary.describe(request.getCapabilities()));
         LoggingPreferences.logDetail(log, "Detailed failure stacktrace", cause);
 
         logScreenshot(driver);

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/runtime/DefaultDriverSessionFactory.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/runtime/DefaultDriverSessionFactory.java
@@ -31,6 +31,10 @@ public class DefaultDriverSessionFactory implements DriverSessionFactory {
         log.info("Creating driver session: description='{}', capabilities={}",
                 request.getDescription(),
                 CapabilitiesSummary.summarize(request.getCapabilities()));
+        if (request.getServerUrl() != null) {
+            log.info("Driver server: {}", sanitizeServerUrl(request.getServerUrl()));
+        }
+        log.info("Effective capabilities: {}", CapabilitiesSummary.describe(request.getCapabilities()));
         WebDriver driver;
 
         switch (request.getDriverType()) {
@@ -61,6 +65,18 @@ public class DefaultDriverSessionFactory implements DriverSessionFactory {
         log.info("Driver session created successfully");
 
         return new DriverSession(driver, request);
+    }
+
+    private String sanitizeServerUrl(URL url) {
+        if (url == null) {
+            return "none";
+        }
+        String userInfo = url.getUserInfo();
+        if (userInfo == null || userInfo.isBlank()) {
+            return url.toString();
+        }
+        String raw = url.toString();
+        return raw.replace(userInfo + "@", "***@");
     }
 
     private URL requireServerUrl(DriverRequest request) {

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/CapabilitiesSummaryTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/CapabilitiesSummaryTest.java
@@ -1,0 +1,45 @@
+package io.github.roberto22palomar.pepenium.core.observability;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.MutableCapabilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CapabilitiesSummaryTest {
+
+    @Test
+    void summarizeUsesFocusedKeysWhenPresent() {
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("platformName", "Android");
+        capabilities.setCapability("appium:deviceName", "Pixel 9");
+        capabilities.setCapability("appium:appPackage", "io.github.example");
+        capabilities.setCapability("customCapability", "ignored");
+
+        String summary = CapabilitiesSummary.summarize(capabilities);
+
+        assertEquals(
+                "platformName=ANDROID, appium:deviceName=Pixel 9, appium:appPackage=io.github.example",
+                summary
+        );
+    }
+
+    @Test
+    void describeIncludesAllCapabilitiesInStableOrderAndRedactsSensitiveValues() {
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("bstack:options", "{deviceName=Pixel 9}");
+        capabilities.setCapability("platformName", "Android");
+        capabilities.setCapability("password", "super-secret");
+        capabilities.setCapability("accessKey", "abc123");
+
+        String description = CapabilitiesSummary.describe(capabilities);
+
+        assertTrue(description.contains("accessKey=***"));
+        assertTrue(description.contains("password=***"));
+        assertTrue(description.contains("platformName=ANDROID"));
+        assertTrue(description.contains("bstack:options={deviceName=Pixel 9}"));
+        assertTrue(description.indexOf("accessKey=***") < description.indexOf("platformName=ANDROID"));
+        assertTrue(description.indexOf("bstack:options={deviceName=Pixel 9}") < description.indexOf("platformName=ANDROID"));
+        assertTrue(description.indexOf("password=***") < description.indexOf("platformName=ANDROID"));
+    }
+}

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporterTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporterTest.java
@@ -108,7 +108,8 @@ class FailureContextReporterTest {
         assertTrue(appender.contains("Failure summary for 'webFailure': IllegalArgumentException - Broken field"));
         assertTrue(appender.contains("Recent steps"));
         assertTrue(appender.contains("Step:"));
-        assertTrue(appender.contains("Capabilities: browserName=chrome"));
+        assertTrue(appender.contains("Capabilities summary: browserName=chrome"));
+        assertTrue(appender.contains("Effective capabilities: browserName=chrome"));
         assertTrue(appender.contains("Session: abcdef123456"));
         assertTrue(appender.contains("Web: url='https://example.test/login', title='Example'"));
     }


### PR DESCRIPTION
## Summary

- log the effective sanitized capabilities used to create driver sessions
- log the sanitized driver server URL when a remote/Appium endpoint is involved
- surface the same effective capability detail in automatic failure reporting
- add focused observability tests for capability formatting and failure-context logging

## Type of Change

- [x] New feature
- [x] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] CI/CD or workflow change
- [ ] Breaking change

## Validation

- [x] `mvn -B -ntp -pl pepenium-core "-Dtest=CapabilitiesSummaryTest,FailureContextReporterTest,DefaultDriverSessionFactoryTest" test`
- [x] Relevant local validation performed
- [x] Documentation updated when needed
- [x] Changelog updated when needed

## Notes for Reviewers

- This intentionally keeps the existing short capability summary and adds a second, fuller "effective capabilities" line for real diagnostics.
- Sensitive capability keys such as `accessKey`, `password`, `secret`, `token` and `apiKey` are redacted before logging.
- Remote/Appium server URLs are also sanitized so embedded credentials are not written to logs.

## Related Issues

- Closes #