### PR TITLE
Improve screenshot path naming and diagnostics

### DIFF
--- a/.env.android.docker-emulator.example
+++ b/.env.android.docker-emulator.example
@@ -1,6 +1,7 @@
 APPIUM_URL=http://localhost:4723
 ANDROID_UDID=android-emulator:5555
 ANDROID_DEVICE_NAME=Android Emulator
+# PEPENIUM_SCREENSHOT_PATH=C:\temp\pepenium-screenshots
 # APP_PATH=C:\path\to\app.apk
 # APP_PACKAGE=com.example.app
 # APP_ACTIVITY=com.example.MainActivity

--- a/.env.android.host-emulator.example
+++ b/.env.android.host-emulator.example
@@ -1,6 +1,7 @@
 APPIUM_URL=http://localhost:4723
 ANDROID_UDID=host.docker.internal:5555
 ANDROID_DEVICE_NAME=Android Emulator
+# PEPENIUM_SCREENSHOT_PATH=C:\temp\pepenium-screenshots
 # APP_PATH=C:\path\to\app.apk
 # APP_PACKAGE=com.example.app
 # APP_ACTIVITY=com.example.MainActivity

--- a/.env.web.example
+++ b/.env.web.example
@@ -1,3 +1,4 @@
 PEPENIUM_BASE_URL=https://the-internet.herokuapp.com/login
 PEPENIUM_WEB_USERNAME=tomsmith
 PEPENIUM_WEB_PASSWORD=SuperSecretPassword!
+# PEPENIUM_SCREENSHOT_PATH=C:\temp\pepenium-screenshots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- Added `PEPENIUM_SCREENSHOT_PATH` as the preferred screenshot output override while keeping `DEVICEFARM_SCREENSHOT_PATH` as a backward-compatible alias for existing and AWS Device Farm setups.
+
+### Improved
+- Improved screenshot diagnostics so failed capture logs now include the target output directory, making path and permissions issues easier to understand.
+
 ## [0.9.6] - 2026-04-07
 
 ### Added

--- a/README.es.md
+++ b/README.es.md
@@ -452,7 +452,7 @@ Pepenium incluye:
 
 - `takeScreenshot()` para capturas mas seguras
 - `takeScreenshotFast()` para checkpoints mas ligeros
-- fallback al directorio temporal cuando `DEVICEFARM_SCREENSHOT_PATH` no esta definido
+- `PEPENIUM_SCREENSHOT_PATH` como override preferido del directorio de screenshots, manteniendo `DEVICEFARM_SCREENSHOT_PATH` como alias legacy
 - un banner ASCII de Pepenium al arrancar una sesion
 - logs compactos con profile, target, driver y sesion corta
 - reporte automatico de fallo con screenshot y contexto de runtime

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ Pepenium includes:
 - `takeScreenshot()` for safer evidence capture
 - `takeScreenshotFast()` for lighter checkpoints
 - HTML test reports under `target/pepenium-reports/`
-- temp-directory fallback when `DEVICEFARM_SCREENSHOT_PATH` is not set
+- `PEPENIUM_SCREENSHOT_PATH` as the preferred screenshot directory override, with `DEVICEFARM_SCREENSHOT_PATH` still supported as a legacy alias
 - a Pepenium ASCII banner when a session starts
 - compact logs with profile, target, driver and short session id
 - automatic failure reporting with screenshot path and runtime context

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -177,8 +177,21 @@ They are intended for advanced mobile runs when the default Appium option sets n
 
 ## Screenshot Output
 
-### `DEVICEFARM_SCREENSHOT_PATH`
+### `pepenium.screenshot.path`
 
+- Type: Java system property
+- Required: No
+- Default fallback: Java temporary directory (`java.io.tmpdir`)
+- Purpose: Preferred override for the base directory where screenshots are written
+- Example:
+
+```text
+-Dpepenium.screenshot.path=C:\temp\pepenium-screenshots
+```
+
+### `PEPENIUM_SCREENSHOT_PATH`
+
+- Type: Environment variable
 - Required: No
 - Default fallback: Java temporary directory (`java.io.tmpdir`)
 - Used by:
@@ -186,7 +199,14 @@ They are intended for advanced mobile runs when the default Appium option sets n
   - Android screenshots
   - iOS screenshots
   - automatic failure screenshots
-- Purpose: Base directory where screenshots are written
+- Purpose: Preferred environment-variable override for the base directory where screenshots are written
+
+### `DEVICEFARM_SCREENSHOT_PATH`
+
+- Type: Environment variable
+- Required: No
+- Purpose: Legacy compatibility alias for screenshot output, still honored for AWS Device Farm and existing setups
+- Recommendation: Prefer `PEPENIUM_SCREENSHOT_PATH` in new local or shared `.env` files
 
 ## Observability
 
@@ -323,5 +343,11 @@ PEPENIUM_BASE_URL=https://example.com
 ```text
 PEPENIUM_DETAIL_LOGGING=true
 PEPENIUM_STEP_TRACKER_LIMIT=20
+```
+
+### Custom Screenshot Directory
+
+```text
+PEPENIUM_SCREENSHOT_PATH=C:\temp\pepenium-screenshots
 ```
 

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -264,6 +264,8 @@ Available helpers:
 
 `takeScreenshotFast()` is useful for rapid checkpoints where you want lighter capture overhead.
 
+Use `PEPENIUM_SCREENSHOT_PATH` to choose a shared screenshot directory in local or CI runs. `DEVICEFARM_SCREENSHOT_PATH` is still supported as a legacy alias for existing AWS Device Farm setups.
+
 ## 11. Where Execution Is Resolved
 
 Core classes involved:

--- a/docs/es/QUICK-START.es.md
+++ b/docs/es/QUICK-START.es.md
@@ -264,6 +264,8 @@ Helpers disponibles:
 
 `takeScreenshotFast()` es util para checkpoints rapidos donde quieres menos coste de captura.
 
+Usa `PEPENIUM_SCREENSHOT_PATH` para elegir un directorio comun de screenshots en local o en CI. `DEVICEFARM_SCREENSHOT_PATH` sigue soportado como alias legacy para setups existentes en AWS Device Farm.
+
 ## 11. Donde Se Resuelve la Ejecucion
 
 Clases principales:

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporter.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporter.java
@@ -94,7 +94,9 @@ public final class FailureContextReporter {
 
             log.error("Screenshot: {}", filePath.toAbsolutePath());
         } catch (Exception e) {
-            log.error("Screenshot: failed to capture ({})", e.getMessage());
+            log.error("Screenshot: failed to capture under '{}' ({})",
+                    resolveScreenshotBaseDir().toAbsolutePath(),
+                    e.getMessage());
         }
     }
 
@@ -185,11 +187,8 @@ public final class FailureContextReporter {
     }
 
     private static Path resolveScreenshotBaseDir() {
-        String baseDir = System.getenv("DEVICEFARM_SCREENSHOT_PATH");
-        if (baseDir == null || baseDir.isBlank()) {
-            baseDir = System.getProperty("java.io.tmpdir", ".");
-        }
-        return baseDir == null || baseDir.isBlank() ? Paths.get(".") : Path.of(baseDir);
+        Path baseDir = ScreenshotPathResolver.resolveBaseDir();
+        return baseDir == null ? Paths.get(".") : baseDir;
     }
 
     private static String rootType(Throwable cause) {

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/ScreenshotPathResolver.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/ScreenshotPathResolver.java
@@ -1,0 +1,31 @@
+package io.github.roberto22palomar.pepenium.core.observability;
+
+import java.nio.file.Path;
+
+public final class ScreenshotPathResolver {
+
+    public static final String SCREENSHOT_PATH_PROPERTY = "pepenium.screenshot.path";
+    public static final String SCREENSHOT_PATH_ENV = "PEPENIUM_SCREENSHOT_PATH";
+    public static final String LEGACY_SCREENSHOT_PATH_ENV = "DEVICEFARM_SCREENSHOT_PATH";
+
+    private ScreenshotPathResolver() {
+    }
+
+    public static Path resolveBaseDir() {
+        String baseDir = System.getProperty(SCREENSHOT_PATH_PROPERTY);
+        if (isBlank(baseDir)) {
+            baseDir = System.getenv(SCREENSHOT_PATH_ENV);
+        }
+        if (isBlank(baseDir)) {
+            baseDir = System.getenv(LEGACY_SCREENSHOT_PATH_ENV);
+        }
+        if (isBlank(baseDir)) {
+            baseDir = System.getProperty("java.io.tmpdir");
+        }
+        return Path.of(baseDir);
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporterTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporterTest.java
@@ -70,6 +70,7 @@ class FailureContextReporterTest {
             System.setProperty("java.io.tmpdir", previousTmpDir);
         }
         System.clearProperty("pepenium.detail.logging");
+        System.clearProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY);
         StepTracker.clear();
     }
 
@@ -82,7 +83,7 @@ class FailureContextReporterTest {
 
     @Test
     void reportWritesScreenshotAndLogsWebContext() throws Exception {
-        System.setProperty("java.io.tmpdir", tempDir.toString());
+        System.setProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY, tempDir.toString());
         StepTracker.record("Open login page");
         MutableCapabilities capabilities = new MutableCapabilities();
         capabilities.setCapability("browserName", "chrome");

--- a/pepenium-toolkit/src/main/java/io/github/roberto22palomar/pepenium/toolkit/actions/ActionsApp.java
+++ b/pepenium-toolkit/src/main/java/io/github/roberto22palomar/pepenium/toolkit/actions/ActionsApp.java
@@ -385,7 +385,8 @@ public class ActionsApp {
 
             byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
             String filename = "screenshot_" + Instant.now().toEpochMilli() + ".png";
-            Path filePath = resolveScreenshotBaseDir().resolve(filename);
+            Path screenshotBaseDir = resolveScreenshotBaseDir();
+            Path filePath = screenshotBaseDir.resolve(filename);
             Files.createDirectories(filePath.getParent());
             Files.write(filePath, screenshot);
 
@@ -395,10 +396,12 @@ public class ActionsApp {
             return fullPath;
 
         } catch (IOException e) {
-            ActionLoggingSupport.logFailure(log, "save screenshot", "driver capture", e);
+            ActionLoggingSupport.logFailure(log, "save screenshot",
+                    "driver capture under " + resolveScreenshotBaseDir().toAbsolutePath(), e);
             return null;
         } catch (Exception e) {
-            ActionLoggingSupport.logFailure(log, "take screenshot", "driver capture", e);
+            ActionLoggingSupport.logFailure(log, "take screenshot",
+                    "driver capture under " + resolveScreenshotBaseDir().toAbsolutePath(), e);
             return null;
         }
     }

--- a/pepenium-toolkit/src/main/java/io/github/roberto22palomar/pepenium/toolkit/actions/ActionsAppIOS.java
+++ b/pepenium-toolkit/src/main/java/io/github/roberto22palomar/pepenium/toolkit/actions/ActionsAppIOS.java
@@ -324,7 +324,8 @@ public class ActionsAppIOS {
 
             byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
             String filename = "screenshot_" + Instant.now().toEpochMilli() + ".png";
-            Path filePath = resolveScreenshotBaseDir().resolve(filename);
+            Path screenshotBaseDir = resolveScreenshotBaseDir();
+            Path filePath = screenshotBaseDir.resolve(filename);
             Files.createDirectories(filePath.getParent());
             Files.write(filePath, screenshot);
             String fullPath = filePath.toAbsolutePath().toString();
@@ -332,10 +333,12 @@ public class ActionsAppIOS {
             ActionLoggingSupport.recordSavedScreenshot(fullPath);
             return fullPath;
         } catch (IOException e) {
-            ActionLoggingSupport.logFailure(log, "save screenshot", "driver capture", e);
+            ActionLoggingSupport.logFailure(log, "save screenshot",
+                    "driver capture under " + resolveScreenshotBaseDir().toAbsolutePath(), e);
             return null;
         } catch (Exception e) {
-            ActionLoggingSupport.logFailure(log, "take screenshot", "driver capture", e);
+            ActionLoggingSupport.logFailure(log, "take screenshot",
+                    "driver capture under " + resolveScreenshotBaseDir().toAbsolutePath(), e);
             return null;
         }
     }

--- a/pepenium-toolkit/src/main/java/io/github/roberto22palomar/pepenium/toolkit/actions/ActionsWeb.java
+++ b/pepenium-toolkit/src/main/java/io/github/roberto22palomar/pepenium/toolkit/actions/ActionsWeb.java
@@ -285,7 +285,8 @@ public class ActionsWeb {
 
             byte[] screenshot = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
             String filename = "screenshot_" + Instant.now().toEpochMilli() + ".png";
-            Path filePath = resolveScreenshotBaseDir().resolve(filename);
+            Path screenshotBaseDir = resolveScreenshotBaseDir();
+            Path filePath = screenshotBaseDir.resolve(filename);
             Files.createDirectories(filePath.getParent());
             Files.write(filePath, screenshot);
 
@@ -295,10 +296,12 @@ public class ActionsWeb {
             return fullPath;
 
         } catch (IOException e) {
-            ActionLoggingSupport.logFailure(log, "save screenshot", "driver capture", e);
+            ActionLoggingSupport.logFailure(log, "save screenshot",
+                    "driver capture under " + resolveScreenshotBaseDir().toAbsolutePath(), e);
             return null;
         } catch (Exception e) {
-            ActionLoggingSupport.logFailure(log, "take screenshot", "driver capture", e);
+            ActionLoggingSupport.logFailure(log, "take screenshot",
+                    "driver capture under " + resolveScreenshotBaseDir().toAbsolutePath(), e);
             return null;
         }
     }

--- a/pepenium-toolkit/src/main/java/io/github/roberto22palomar/pepenium/toolkit/support/ActionLoggingSupport.java
+++ b/pepenium-toolkit/src/main/java/io/github/roberto22palomar/pepenium/toolkit/support/ActionLoggingSupport.java
@@ -2,6 +2,7 @@ package io.github.roberto22palomar.pepenium.toolkit.support;
 
 import io.github.roberto22palomar.pepenium.core.observability.LoggingPreferences;
 import io.github.roberto22palomar.pepenium.core.observability.PepeniumTimeline;
+import io.github.roberto22palomar.pepenium.core.observability.ScreenshotPathResolver;
 import org.slf4j.Logger;
 
 import java.nio.file.Path;
@@ -38,11 +39,7 @@ public final class ActionLoggingSupport {
     }
 
     public static Path resolveScreenshotBaseDir() {
-        String baseDir = System.getenv("DEVICEFARM_SCREENSHOT_PATH");
-        if (baseDir == null || baseDir.isBlank()) {
-            baseDir = System.getProperty("java.io.tmpdir");
-        }
-        return Path.of(baseDir);
+        return ScreenshotPathResolver.resolveBaseDir();
     }
 
     public static void recordSavedScreenshot(String fullPath) {

--- a/pepenium-toolkit/src/test/java/io/github/roberto22palomar/pepenium/toolkit/actions/ActionsWebTest.java
+++ b/pepenium-toolkit/src/test/java/io/github/roberto22palomar/pepenium/toolkit/actions/ActionsWebTest.java
@@ -1,6 +1,7 @@
 package io.github.roberto22palomar.pepenium.toolkit.actions;
 
 import io.github.roberto22palomar.pepenium.core.observability.StepTracker;
+import io.github.roberto22palomar.pepenium.core.observability.ScreenshotPathResolver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,10 +51,12 @@ class ActionsWebTest {
     private Path tempDir;
 
     private String previousTmpDir;
+    private String previousScreenshotPath;
 
     @BeforeEach
     void captureTmpDir() {
         previousTmpDir = System.getProperty("java.io.tmpdir");
+        previousScreenshotPath = System.getProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY);
     }
 
     @AfterEach
@@ -62,6 +65,11 @@ class ActionsWebTest {
             System.clearProperty("java.io.tmpdir");
         } else {
             System.setProperty("java.io.tmpdir", previousTmpDir);
+        }
+        if (previousScreenshotPath == null) {
+            System.clearProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY);
+        } else {
+            System.setProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY, previousScreenshotPath);
         }
         StepTracker.clear();
     }
@@ -253,7 +261,7 @@ class ActionsWebTest {
         WebDriver screenshotDriver = mock(WebDriver.class, withSettings().extraInterfaces(TakesScreenshot.class));
         when(((TakesScreenshot) screenshotDriver).getScreenshotAs(OutputType.BYTES))
                 .thenReturn("png".getBytes(StandardCharsets.UTF_8));
-        System.setProperty("java.io.tmpdir", tempDir.toString());
+        System.setProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY, tempDir.toString());
 
         ActionsWeb actions = new ActionsWeb(screenshotDriver);
         String screenshotPath = actions.takeScreenshotFast();

--- a/pepenium-toolkit/src/test/java/io/github/roberto22palomar/pepenium/toolkit/support/ActionLoggingSupportTest.java
+++ b/pepenium-toolkit/src/test/java/io/github/roberto22palomar/pepenium/toolkit/support/ActionLoggingSupportTest.java
@@ -1,5 +1,6 @@
 package io.github.roberto22palomar.pepenium.toolkit.support;
 
+import io.github.roberto22palomar.pepenium.core.observability.ScreenshotPathResolver;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
@@ -10,6 +11,23 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 class ActionLoggingSupportTest {
+
+    @Test
+    void resolveScreenshotBaseDirUsesDedicatedPepeniumPropertyWhenPresent() {
+        String previous = System.getProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY);
+        System.setProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY, "C:\\temp\\pepenium-shots");
+
+        try {
+            Path resolved = ActionLoggingSupport.resolveScreenshotBaseDir();
+            assertEquals(Path.of("C:\\temp\\pepenium-shots"), resolved);
+        } finally {
+            if (previous == null) {
+                System.clearProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY);
+            } else {
+                System.setProperty(ScreenshotPathResolver.SCREENSHOT_PATH_PROPERTY, previous);
+            }
+        }
+    }
 
     @Test
     void resolveScreenshotBaseDirFallsBackToJavaTmpDir() {


### PR DESCRIPTION
## Summary

- add a clearer screenshot output naming model with `PEPENIUM_SCREENSHOT_PATH` as the preferred override
- keep `DEVICEFARM_SCREENSHOT_PATH` working as a backward-compatible alias for existing and AWS Device Farm setups
- improve screenshot diagnostics and docs so path resolution is easier to understand in local and CI runs

## Type of Change

- [ ] Bug fix
- [x] Refactor
- [x] New feature
- [x] Documentation update
- [ ] CI/CD or workflow change
- [ ] Breaking change

## Validation

- [x] `mvn -q -DskipTests test-compile`
- [x] Relevant local validation performed
- [x] Documentation updated when needed
- [x] Changelog updated when needed

## Notes for Reviewers

- This PR intentionally keeps legacy compatibility: existing `DEVICEFARM_SCREENSHOT_PATH` setups still work.
- The new name is `PEPENIUM_SCREENSHOT_PATH`, and a matching system property `pepenium.screenshot.path` is now supported for clearer local and CI configuration.
- Failed screenshot capture logs now include the resolved output directory to make permissions/path issues easier to diagnose.
- Local untracked PDF/HTML files under `docs/` were intentionally left out.

## Related Issues

- Closes #