### PR TITLE
Add local web capability overrides

### DIFF
--- a/.env.web.capabilities.example
+++ b/.env.web.capabilities.example
@@ -1,0 +1,18 @@
+PEPENIUM_PROFILE=local-web
+PEPENIUM_BASE_URL=https://the-internet.herokuapp.com/login
+
+# Common desktop-web driver tuning
+# PEPENIUM_WEB_HEADLESS=true
+# PEPENIUM_WEB_ACCEPT_INSECURE_CERTS=true
+# PEPENIUM_WEB_PAGE_LOAD_STRATEGY=eager
+# PEPENIUM_WEB_BROWSER_VERSION=135
+# PEPENIUM_WEB_BINARY_PATH=C:\Program Files\Google\Chrome\Application\chrome.exe
+
+# Browser arguments are separated with ';'
+# PEPENIUM_WEB_ARGS=--incognito;--window-size=1920,1080
+
+# Arbitrary extra capabilities also use ';' and key=value format
+# PEPENIUM_WEB_CAPABILITIES=custom:flag=true;custom:retries=3
+
+# Observability
+# PEPENIUM_SCREENSHOT_PATH=C:\temp\pepenium-screenshots

--- a/.env.web.example
+++ b/.env.web.example
@@ -1,4 +1,6 @@
+PEPENIUM_PROFILE=local-web
 PEPENIUM_BASE_URL=https://the-internet.herokuapp.com/login
 PEPENIUM_WEB_USERNAME=tomsmith
 PEPENIUM_WEB_PASSWORD=SuperSecretPassword!
 # PEPENIUM_SCREENSHOT_PATH=C:\temp\pepenium-screenshots
+# For driver tuning, see .env.web.capabilities.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Added optional `PEPENIUM_WEB_*` overrides for the built-in local desktop web profiles so Chrome, Firefox and Edge runs can be tuned from environment variables without custom driver config classes.
+
 ### Changed
 - Added `PEPENIUM_SCREENSHOT_PATH` as the preferred screenshot output override while keeping `DEVICEFARM_SCREENSHOT_PATH` as a backward-compatible alias for existing and AWS Device Farm setups.
 

--- a/README.es.md
+++ b/README.es.md
@@ -42,6 +42,7 @@ Primeros pasos recomendados:
 Ficheros de entorno listos para copiar:
 
 - [`.env.web.example`](.env.web.example)
+- [`.env.web.capabilities.example`](.env.web.capabilities.example)
 - [`.env.android.host-emulator.example`](.env.android.host-emulator.example)
 - [`.env.android.docker-emulator.example`](.env.android.docker-emulator.example)
 
@@ -55,7 +56,7 @@ Ficheros de entorno listos para copiar:
 - Logs mas limpios con contexto automatico y evidencia de fallo
 
 Consulta [START-HERE.es.md](docs/es/START-HERE.es.md) para el camino mas rapido al primer uso, [QUICK-START.es.md](docs/es/QUICK-START.es.md) para la guia mas completa y [CHANGELOG.md](CHANGELOG.md) para el historico de versiones.
-Usa [ENVIRONMENT.md](docs/ENVIRONMENT.md) como referencia central de variables de entorno y properties de runtime.
+Usa [ENVIRONMENT.md](docs/ENVIRONMENT.md) como referencia central de variables de entorno, properties de runtime y patrones de override de capabilities.
 Usa el `docker-compose.yaml` de la raiz si quieres ejecutar el servidor Appium local en Docker mientras el emulador Android sigue en el host.
 Usa [consumer-smoke/README.md](consumer-smoke/README.md) si quieres validar el consumo de la API publica desde un proyecto Maven separado.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Recommended first steps:
 Ready-to-copy environment examples:
 
 - [`.env.web.example`](.env.web.example)
+- [`.env.web.capabilities.example`](.env.web.capabilities.example)
 - [`.env.android.host-emulator.example`](.env.android.host-emulator.example)
 - [`.env.android.docker-emulator.example`](.env.android.docker-emulator.example)
 
@@ -55,7 +56,7 @@ Ready-to-copy environment examples:
 - Cleaner logs with automatic runtime context and failure evidence
 
 See [START-HERE.md](docs/START-HERE.md) for the fastest first-run path, [QUICK-START.md](docs/QUICK-START.md) for the fuller walkthrough and [CHANGELOG.md](CHANGELOG.md) for release history.
-Use [ENVIRONMENT.md](docs/ENVIRONMENT.md) as the central reference for environment variables and runtime properties.
+Use [ENVIRONMENT.md](docs/ENVIRONMENT.md) as the central reference for environment variables, runtime properties and capability override patterns.
 Use [API.md](docs/API.md) for the current public-vs-internal API guidance on the road to `1.0.0`.
 Use the root `docker-compose.yaml` if you want to run the local Appium server in Docker while keeping the Android emulator on the host.
 Use [consumer-smoke/README.md](consumer-smoke/README.md) for the standalone public-API consumer smoke validation flow.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -7,6 +7,7 @@ It is intended to be the single reference point for configuring local runs, remo
 Ready-to-copy examples for common local setups:
 
 - [`.env.web.example`](../.env.web.example)
+- [`.env.web.capabilities.example`](../.env.web.capabilities.example)
 - [`.env.android.host-emulator.example`](../.env.android.host-emulator.example)
 - [`.env.android.docker-emulator.example`](../.env.android.docker-emulator.example)
 
@@ -139,6 +140,29 @@ They are intended for advanced mobile runs when the default Appium option sets n
   - Android web example
   - iOS web example
 - Purpose: Base URL opened by the example tests
+
+### Optional local desktop web capability overrides
+
+These optional environment variables are supported by the built-in local desktop web profiles:
+
+- `local-web`
+- `local-web-firefox`
+- `local-web-edge`
+
+- `PEPENIUM_WEB_HEADLESS`
+- `PEPENIUM_WEB_ACCEPT_INSECURE_CERTS`
+- `PEPENIUM_WEB_PAGE_LOAD_STRATEGY`
+- `PEPENIUM_WEB_BROWSER_VERSION`
+- `PEPENIUM_WEB_BINARY_PATH`
+- `PEPENIUM_WEB_ARGS`
+- `PEPENIUM_WEB_CAPABILITIES`
+
+Notes:
+
+- `PEPENIUM_WEB_ARGS` uses `;` as separator, for example `--incognito;--window-size=1920,1080`
+- `PEPENIUM_WEB_CAPABILITIES` also uses `;` and `key=value` entries, for example `custom:flag=true;custom:retries=3`
+- `PEPENIUM_WEB_HEADLESS=true` maps to the browser-specific headless argument for Chromium and Firefox
+- `PEPENIUM_WEB_PAGE_LOAD_STRATEGY` accepts `normal`, `eager` or `none`
 
 ## AWS Device Farm
 
@@ -335,7 +359,20 @@ APP_PATH=C:\apps\my-app.apk
 ### Local Desktop Web
 
 ```text
+PEPENIUM_PROFILE=local-web
 PEPENIUM_BASE_URL=https://example.com
+```
+
+### Local Desktop Web With Driver Tuning
+
+```text
+PEPENIUM_PROFILE=local-web
+PEPENIUM_BASE_URL=https://example.com
+PEPENIUM_WEB_HEADLESS=true
+PEPENIUM_WEB_ACCEPT_INSECURE_CERTS=true
+PEPENIUM_WEB_PAGE_LOAD_STRATEGY=eager
+PEPENIUM_WEB_ARGS=--incognito;--window-size=1920,1080
+PEPENIUM_WEB_CAPABILITIES=custom:flag=true;custom:retries=3
 ```
 
 ### Detailed Diagnostics

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverrides.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverrides.java
@@ -1,0 +1,213 @@
+package io.github.roberto22palomar.pepenium.core.config.validation;
+
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.AbstractDriverOptions;
+
+import java.util.function.Function;
+
+public final class WebCapabilityOverrides {
+
+    private WebCapabilityOverrides() {
+    }
+
+    public static void applyChrome(Function<String, String> env, ChromeOptions options) {
+        applyCommon(env, options, BrowserKind.CHROMIUM);
+    }
+
+    public static void applyFirefox(Function<String, String> env, FirefoxOptions options) {
+        applyCommon(env, options, BrowserKind.FIREFOX);
+    }
+
+    public static void applyEdge(Function<String, String> env, EdgeOptions options) {
+        applyCommon(env, options, BrowserKind.CHROMIUM);
+    }
+
+    private static void applyCommon(Function<String, String> env,
+                                    AbstractDriverOptions<?> options,
+                                    BrowserKind browserKind) {
+        applyBoolean(env, "PEPENIUM_WEB_ACCEPT_INSECURE_CERTS", options::setAcceptInsecureCerts);
+        applyString(env, "PEPENIUM_WEB_BROWSER_VERSION", options::setBrowserVersion);
+        applyBinary(env, options, browserKind);
+        applyPageLoadStrategy(env, options);
+        applyArguments(env, options, browserKind);
+        applyHeadless(env, options, browserKind);
+        applyGenericCapabilities(env, options);
+    }
+
+    private static void applyPageLoadStrategy(Function<String, String> env, AbstractDriverOptions<?> options) {
+        String value = envValue(env, "PEPENIUM_WEB_PAGE_LOAD_STRATEGY");
+        if (value == null) {
+            return;
+        }
+        try {
+            options.setPageLoadStrategy(PageLoadStrategy.fromString(value));
+        } catch (RuntimeException ex) {
+            throw new IllegalStateException(
+                    "PEPENIUM_WEB_PAGE_LOAD_STRATEGY must be one of 'normal', 'eager' or 'none'.", ex);
+        }
+    }
+
+    private static void applyBinary(Function<String, String> env,
+                                    AbstractDriverOptions<?> options,
+                                    BrowserKind browserKind) {
+        String value = envValue(env, "PEPENIUM_WEB_BINARY_PATH");
+        if (value != null) {
+            browserKind.setBinary(options, value);
+        }
+    }
+
+    private static void applyArguments(Function<String, String> env,
+                                       AbstractDriverOptions<?> options,
+                                       BrowserKind browserKind) {
+        String value = envValue(env, "PEPENIUM_WEB_ARGS");
+        if (value == null) {
+            return;
+        }
+        for (String rawArg : value.split(";")) {
+            String arg = rawArg == null ? null : rawArg.trim();
+            if (arg == null || arg.isBlank()) {
+                continue;
+            }
+            browserKind.addArgument(options, arg);
+        }
+    }
+
+    private static void applyHeadless(Function<String, String> env,
+                                      AbstractDriverOptions<?> options,
+                                      BrowserKind browserKind) {
+        String value = envValue(env, "PEPENIUM_WEB_HEADLESS");
+        if (value == null || !parseBoolean("PEPENIUM_WEB_HEADLESS", value)) {
+            return;
+        }
+        browserKind.addHeadlessArgument(options);
+    }
+
+    private static void applyGenericCapabilities(Function<String, String> env, AbstractDriverOptions<?> options) {
+        String value = envValue(env, "PEPENIUM_WEB_CAPABILITIES");
+        if (value == null) {
+            return;
+        }
+        for (String rawEntry : value.split(";")) {
+            String entry = rawEntry == null ? null : rawEntry.trim();
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+            int separator = entry.indexOf('=');
+            if (separator <= 0 || separator == entry.length() - 1) {
+                throw new IllegalStateException(
+                        "PEPENIUM_WEB_CAPABILITIES entries must follow key=value format and be separated with ';'.");
+            }
+            String key = entry.substring(0, separator).trim();
+            String rawValue = entry.substring(separator + 1).trim();
+            if (key.isBlank() || rawValue.isBlank()) {
+                throw new IllegalStateException(
+                        "PEPENIUM_WEB_CAPABILITIES entries must follow key=value format and be separated with ';'.");
+            }
+            options.setCapability(key, parseScalar(rawValue));
+        }
+    }
+
+    private static void applyString(Function<String, String> env,
+                                    String key,
+                                    java.util.function.Consumer<String> setter) {
+        String value = envValue(env, key);
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+
+    private static void applyBoolean(Function<String, String> env,
+                                     String key,
+                                     java.util.function.Consumer<Boolean> setter) {
+        String value = envValue(env, key);
+        if (value != null) {
+            setter.accept(parseBoolean(key, value));
+        }
+    }
+
+    private static String envValue(Function<String, String> env, String key) {
+        String value = env.apply(key);
+        return (value == null || value.isBlank()) ? null : value.trim();
+    }
+
+    private static boolean parseBoolean(String key, String value) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        throw new IllegalStateException(key + " must be either 'true' or 'false'.");
+    }
+
+    private static Object parseScalar(String rawValue) {
+        String value = rawValue.trim();
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ignored) {
+        }
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ignored) {
+        }
+        return value;
+    }
+
+    private enum BrowserKind {
+        CHROMIUM {
+            @Override
+            void addArgument(AbstractDriverOptions<?> options, String argument) {
+                if (options instanceof ChromeOptions) {
+                    ((ChromeOptions) options).addArguments(argument);
+                    return;
+                }
+                ((EdgeOptions) options).addArguments(argument);
+            }
+
+            @Override
+            void addHeadlessArgument(AbstractDriverOptions<?> options) {
+                addArgument(options, "--headless=new");
+            }
+
+            @Override
+            void setBinary(AbstractDriverOptions<?> options, String binaryPath) {
+                if (options instanceof ChromeOptions) {
+                    ((ChromeOptions) options).setBinary(binaryPath);
+                    return;
+                }
+                ((EdgeOptions) options).setBinary(binaryPath);
+            }
+        },
+        FIREFOX {
+            @Override
+            void addArgument(AbstractDriverOptions<?> options, String argument) {
+                ((FirefoxOptions) options).addArguments(argument);
+            }
+
+            @Override
+            void addHeadlessArgument(AbstractDriverOptions<?> options) {
+                addArgument(options, "-headless");
+            }
+
+            @Override
+            void setBinary(AbstractDriverOptions<?> options, String binaryPath) {
+                ((FirefoxOptions) options).setBinary(binaryPath);
+            }
+        };
+
+        abstract void addArgument(AbstractDriverOptions<?> options, String argument);
+
+        abstract void addHeadlessArgument(AbstractDriverOptions<?> options);
+
+        abstract void setBinary(AbstractDriverOptions<?> options, String binaryPath);
+    }
+}

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/ChromeWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/ChromeWebConfigLocal.java
@@ -1,5 +1,6 @@
 package io.github.roberto22palomar.pepenium.core.configs.local.desktop;
 
+import io.github.roberto22palomar.pepenium.core.config.validation.WebCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -11,6 +12,7 @@ public class ChromeWebConfigLocal implements DriverConfig {
     public DriverRequest createRequest() {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("start-maximized");
+        WebCapabilityOverrides.applyChrome(System::getenv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_CHROME)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/EdgeWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/EdgeWebConfigLocal.java
@@ -1,5 +1,6 @@
 package io.github.roberto22palomar.pepenium.core.configs.local.desktop;
 
+import io.github.roberto22palomar.pepenium.core.config.validation.WebCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -11,6 +12,7 @@ public class EdgeWebConfigLocal implements DriverConfig {
     public DriverRequest createRequest() {
         EdgeOptions options = new EdgeOptions();
         options.addArguments("start-maximized");
+        WebCapabilityOverrides.applyEdge(System::getenv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_EDGE)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/FirefoxWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/FirefoxWebConfigLocal.java
@@ -1,5 +1,6 @@
 package io.github.roberto22palomar.pepenium.core.configs.local.desktop;
 
+import io.github.roberto22palomar.pepenium.core.config.validation.WebCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -12,6 +13,7 @@ public class FirefoxWebConfigLocal implements DriverConfig {
         FirefoxOptions options = new FirefoxOptions();
         options.addArguments("--width=1920");
         options.addArguments("--height=1080");
+        WebCapabilityOverrides.applyFirefox(System::getenv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_FIREFOX)

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverridesTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverridesTest.java
@@ -1,0 +1,94 @@
+package io.github.roberto22palomar.pepenium.core.config.validation;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebCapabilityOverridesTest {
+
+    @Test
+    void applyChromeSupportsHeadlessArgsAndGenericCapabilities() {
+        ChromeOptions options = new ChromeOptions();
+
+        WebCapabilityOverrides.applyChrome(Map.of(
+                "PEPENIUM_WEB_HEADLESS", "true",
+                "PEPENIUM_WEB_ACCEPT_INSECURE_CERTS", "true",
+                "PEPENIUM_WEB_PAGE_LOAD_STRATEGY", "eager",
+                "PEPENIUM_WEB_ARGS", "--incognito;--window-size=1920,1080",
+                "PEPENIUM_WEB_CAPABILITIES", "custom:flag=true;custom:retries=3;custom:ratio=1.5"
+        )::get, options);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> chromeOptions = (Map<String, Object>) options.getCapability("goog:chromeOptions");
+        assertTrue(((java.util.List<String>) chromeOptions.get("args")).contains("--headless=new"));
+        assertTrue(((java.util.List<String>) chromeOptions.get("args")).contains("--incognito"));
+        assertTrue(((java.util.List<String>) chromeOptions.get("args")).contains("--window-size=1920,1080"));
+        assertEquals(Boolean.TRUE, options.getCapability("acceptInsecureCerts"));
+        assertEquals(PageLoadStrategy.EAGER, options.getCapability("pageLoadStrategy"));
+        assertEquals(Boolean.TRUE, options.getCapability("custom:flag"));
+        assertEquals(3L, options.getCapability("custom:retries"));
+        assertEquals(1.5d, options.getCapability("custom:ratio"));
+    }
+
+    @Test
+    void applyFirefoxSupportsBinaryAndHeadless() {
+        FirefoxOptions options = new FirefoxOptions();
+
+        WebCapabilityOverrides.applyFirefox(Map.of(
+                "PEPENIUM_WEB_HEADLESS", "true",
+                "PEPENIUM_WEB_BINARY_PATH", "C:\\firefox\\firefox.exe"
+        )::get, options);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> firefoxOptions = (Map<String, Object>) options.getCapability("moz:firefoxOptions");
+        assertTrue(((java.util.List<String>) firefoxOptions.get("args")).contains("-headless"));
+        assertEquals("C:\\firefox\\firefox.exe", firefoxOptions.get("binary"));
+    }
+
+    @Test
+    void applyEdgeSupportsArgsAndBrowserVersion() {
+        EdgeOptions options = new EdgeOptions();
+
+        WebCapabilityOverrides.applyEdge(Map.of(
+                "PEPENIUM_WEB_ARGS", "--inprivate",
+                "PEPENIUM_WEB_BROWSER_VERSION", "135"
+        )::get, options);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> edgeOptions = (Map<String, Object>) options.getCapability("ms:edgeOptions");
+        assertTrue(((java.util.List<String>) edgeOptions.get("args")).contains("--inprivate"));
+        assertEquals("135", options.getBrowserVersion());
+    }
+
+    @Test
+    void applyThrowsOnInvalidBoolean() {
+        ChromeOptions options = new ChromeOptions();
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> WebCapabilityOverrides.applyChrome(Map.of("PEPENIUM_WEB_HEADLESS", "maybe")::get, options));
+
+        assertEquals("PEPENIUM_WEB_HEADLESS must be either 'true' or 'false'.", error.getMessage());
+    }
+
+    @Test
+    void applyThrowsOnMalformedCapabilitiesList() {
+        ChromeOptions options = new ChromeOptions();
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> WebCapabilityOverrides.applyChrome(
+                        Map.of("PEPENIUM_WEB_CAPABILITIES", "bad-entry")::get,
+                        options));
+
+        assertEquals(
+                "PEPENIUM_WEB_CAPABILITIES entries must follow key=value format and be separated with ';'.",
+                error.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

- add optional `PEPENIUM_WEB_*` capability overrides for the built-in local desktop web profiles
- support common web-driver tuning such as headless mode, browser args, insecure certs and page-load strategy
- document the new desktop-web overrides and add a ready-to-copy `.env` example

## Type of Change

- [ ] Bug fix
- [x] Refactor
- [x] New feature
- [x] Documentation update
- [ ] CI/CD or workflow change
- [ ] Breaking change

## Validation

- [x] `mvn -q -DskipTests test-compile`
- [x] Relevant local validation performed
- [x] Documentation updated when needed
- [x] Changelog updated when needed

## Notes for Reviewers

- This PR is scoped to the built-in local desktop web profiles: `local-web`, `local-web-firefox` and `local-web-edge`.
- `PEPENIUM_WEB_ARGS` uses `;` as a separator so arguments like `--window-size=1920,1080` can be passed without ambiguity.
- `PEPENIUM_WEB_CAPABILITIES` is the escape hatch for arbitrary extra capabilities using `key=value;key2=value2` format with basic scalar parsing.
- Local untracked PDF/HTML files under `docs/` were intentionally left out.

## Related Issues

- Closes #