### PR TITLE
Bundle report screenshots into report artifacts

### DIFF
--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumHtmlReportWriter.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumHtmlReportWriter.java
@@ -245,6 +245,7 @@ public final class PepeniumHtmlReportWriter {
         final String mobilePackage;
         final String mobileActivity;
         final DeviceContext deviceContext;
+        final Path reportDir;
         final String capabilitiesSummary;
         final StepTracker.Snapshot stepSnapshot;
         final PepeniumTimeline.Snapshot timelineSnapshot;
@@ -287,6 +288,7 @@ public final class PepeniumHtmlReportWriter {
                 String mobilePackage,
                 String mobileActivity,
                 DeviceContext deviceContext,
+                Path reportDir,
                 String capabilitiesSummary,
                 StepTracker.Snapshot stepSnapshot,
                 PepeniumTimeline.Snapshot timelineSnapshot,
@@ -328,6 +330,7 @@ public final class PepeniumHtmlReportWriter {
             this.mobilePackage = mobilePackage;
             this.mobileActivity = mobileActivity;
             this.deviceContext = deviceContext;
+            this.reportDir = reportDir;
             this.capabilitiesSummary = capabilitiesSummary;
             this.stepSnapshot = stepSnapshot;
             this.timelineSnapshot = timelineSnapshot;

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollector.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollector.java
@@ -23,7 +23,10 @@ final class PepeniumReportCollector {
     static PepeniumHtmlReportWriter.ReportContext collect(String testName, DriverSession session, Throwable cause, Path reportDir) {
         Instant finishedAt = Instant.now();
         StepTracker.Snapshot stepSnapshot = StepTracker.snapshot();
-        PepeniumTimeline.Snapshot timelineSnapshot = PepeniumTimeline.snapshot();
+        PepeniumTimeline.Snapshot timelineSnapshot = PepeniumTimeline.remapScreenshotPaths(
+                PepeniumTimeline.snapshot(),
+                screenshotPath -> PepeniumReportSupport.bundleScreenshotArtifact(screenshotPath, reportDir)
+        );
         DriverRequest request = session == null ? null : session.getRequest();
         WebDriver driver = session == null ? null : session.getDriver();
         String outcome = cause == null ? "PASSED" : "FAILED";
@@ -50,6 +53,7 @@ final class PepeniumReportCollector {
                 PepeniumReportSupport.safe(PepeniumReportSupport.mobilePackage(driver)),
                 PepeniumReportSupport.safe(PepeniumReportSupport.mobileActivity(driver)),
                 deviceContext,
+                reportDir,
                 PepeniumReportSupport.safe(CapabilitiesSummary.summarize(request == null ? null : request.getCapabilities())),
                 stepSnapshot,
                 timelineSnapshot,

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportHtmlRenderer.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportHtmlRenderer.java
@@ -97,14 +97,14 @@ final class PepeniumReportHtmlRenderer {
             html.append("<div class=\"timeline-preview\">");
             int previewCount = Math.min(5, keyTimelineEvents.size());
             for (int i = 0; i < previewCount; i++) {
-                html.append(renderTimelineCard(keyTimelineEvents.get(i), report.startedAt, null));
+                html.append(renderTimelineCard(keyTimelineEvents.get(i), report.startedAt, null, report.reportDir));
             }
             html.append("</div>");
             if (keyTimelineEvents.size() > previewCount) {
                 html.append("<details class=\"more-link\"><summary>View more key events (")
                         .append(keyTimelineEvents.size() - previewCount).append(" more)</summary><div class=\"timeline\" style=\"margin-top:12px;\">");
                 for (int i = previewCount; i < keyTimelineEvents.size(); i++) {
-                    html.append(renderTimelineCard(keyTimelineEvents.get(i), report.startedAt, null));
+                    html.append(renderTimelineCard(keyTimelineEvents.get(i), report.startedAt, null, report.reportDir));
                 }
                 html.append("</div></details>");
             }
@@ -146,7 +146,7 @@ final class PepeniumReportHtmlRenderer {
             html.append("<div class=\"empty\">No timeline events were recorded for this test.</div>");
         } else {
             for (PepeniumHtmlReportWriter.EventGroup group : report.eventGroups) {
-                html.append(renderTimelineCard(group.anchorEvent, report.startedAt, group));
+                html.append(renderTimelineCard(group.anchorEvent, report.startedAt, group, report.reportDir));
             }
         }
         html.append("</div></details></div></section>");
@@ -205,7 +205,7 @@ final class PepeniumReportHtmlRenderer {
             html.append(renderArtifactLink("Final screenshot", report.screenshotUri));
         }
         if (report.lastScreenshotPath != null) {
-            html.append(renderArtifactLink("Last manual screenshot", PepeniumReportSupport.pathToUri(report.lastScreenshotPath)));
+            html.append(renderArtifactLink("Last manual screenshot", PepeniumReportSupport.pathToHref(report.lastScreenshotPath, report.reportDir)));
         }
         if (report.remoteContext.enabled && report.remoteContext.dashboardUrl != null) {
             html.append(renderArtifactLink("Remote dashboard", report.remoteContext.dashboardUrl));
@@ -310,7 +310,8 @@ final class PepeniumReportHtmlRenderer {
     }
 
     private static String renderTimelineCard(PepeniumTimeline.Event anchor, Instant startedAt,
-                                             PepeniumHtmlReportWriter.EventGroup group) {
+                                             PepeniumHtmlReportWriter.EventGroup group,
+                                             java.nio.file.Path reportDir) {
         StringBuilder html = new StringBuilder();
         html.append("<article class=\"timeline-card ")
                 .append(timelineCardClass(anchor))
@@ -330,7 +331,7 @@ final class PepeniumReportHtmlRenderer {
                     .append(group.screenshots.size() == 1 ? " screenshot" : " screenshots")
                     .append("</summary><div class=\"attachments\">");
             for (PepeniumTimeline.Event screenshot : group.screenshots) {
-                String screenshotUri = PepeniumReportSupport.pathToUri(screenshot.getScreenshotPath());
+                String screenshotUri = PepeniumReportSupport.pathToHref(screenshot.getScreenshotPath(), reportDir);
                 html.append("<div class=\"attachment\"><div>")
                         .append(renderEventTypeBadge(screenshot))
                         .append("<span class=\"timeline-time\">").append(PepeniumReportSupport.escapeHtml(screenshot.getTime())).append("</span></div>")

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
@@ -144,6 +144,9 @@ final class PepeniumReportSupport {
         if (originalPath == null || originalPath.isBlank()) {
             return null;
         }
+        if (reportDir == null) {
+            return originalPath;
+        }
         try {
             Path source = Path.of(originalPath).normalize();
             if (!Files.exists(source) || Files.isDirectory(source)) {

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
@@ -15,6 +15,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -133,14 +134,50 @@ final class PepeniumReportSupport {
             Files.createDirectories(screenshotDir);
             Path screenshotPath = screenshotDir.resolve("report_" + Instant.now().toEpochMilli() + ".png");
             Files.write(screenshotPath, screenshot);
-            return screenshotPath.toUri().toString();
+            return pathToHref(screenshotPath.toString(), reportDir);
         } catch (Exception e) {
             return null;
         }
     }
 
-    static String pathToUri(String path) {
-        return path == null ? null : Path.of(path).toUri().toString();
+    static String bundleScreenshotArtifact(String originalPath, Path reportDir) {
+        if (originalPath == null || originalPath.isBlank()) {
+            return null;
+        }
+        try {
+            Path source = Path.of(originalPath).normalize();
+            if (!Files.exists(source) || Files.isDirectory(source)) {
+                return originalPath;
+            }
+            Path screenshotDir = reportDir.resolve("screenshots");
+            Files.createDirectories(screenshotDir);
+            String fileName = source.getFileName() == null ? "manual.png" : source.getFileName().toString();
+            Path target = screenshotDir.resolve("manual_" + Instant.now().toEpochMilli() + "_" + fileName).normalize();
+            if (!source.equals(target)) {
+                Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+            return target.toString();
+        } catch (Exception ignored) {
+            return originalPath;
+        }
+    }
+
+    static String pathToHref(String path, Path reportDir) {
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+        try {
+            Path resolved = Path.of(path).normalize();
+            if (reportDir != null && resolved.isAbsolute()) {
+                Path normalizedReportDir = reportDir.toAbsolutePath().normalize();
+                if (resolved.startsWith(normalizedReportDir)) {
+                    return normalizedReportDir.relativize(resolved).toString().replace('\\', '/');
+                }
+            }
+            return resolved.isAbsolute() ? resolved.toUri().toString() : resolved.toString().replace('\\', '/');
+        } catch (Exception ignored) {
+            return path;
+        }
     }
 
     static Path resolveReportDir() {

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumTimeline.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumTimeline.java
@@ -6,6 +6,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public final class PepeniumTimeline {
 
@@ -56,6 +57,25 @@ public final class PepeniumTimeline {
     public static void clear() {
         EVENTS.remove();
         STARTED_AT.remove();
+    }
+
+    static Snapshot remapScreenshotPaths(Snapshot snapshot, Function<String, String> mapper) {
+        List<Event> remapped = new ArrayList<>();
+        for (Event event : snapshot.getEvents()) {
+            String screenshotPath = event.getScreenshotPath();
+            if (screenshotPath != null) {
+                screenshotPath = mapper.apply(screenshotPath);
+            }
+            remapped.add(new Event(
+                    event.getEpochMillis(),
+                    event.getTime(),
+                    event.getType(),
+                    event.getStatus(),
+                    event.getMessage(),
+                    screenshotPath
+            ));
+        }
+        return new Snapshot(remapped, snapshot.getStartedAt());
     }
 
     private static void record(EventType type, EventStatus status, String message, String screenshotPath) {

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollectorTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollectorTest.java
@@ -15,7 +15,6 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.SessionId;
 
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,12 +41,13 @@ class PepeniumReportCollectorTest {
 
     @Test
     void collectCapturesRemoteContextTimelineAndScreenshotArtifacts() throws Exception {
+        Path manualScreenshot = Files.write(reportDir.resolve("manual-source.png"), new byte[]{9, 8, 7});
         StepTracker.record("Open login page");
         PepeniumTimeline.recordAction("Submit credentials");
         PepeniumTimeline.recordWait("Wait for secure area");
         PepeniumTimeline.recordWait("Wait for secure area");
         PepeniumTimeline.recordAssertionFailed("Assert secure area is visible");
-        PepeniumTimeline.recordScreenshot("Manual screenshot", "C:\\tmp\\manual.png");
+        PepeniumTimeline.recordScreenshot("Manual screenshot", manualScreenshot.toString());
         PepeniumTimeline.recordError("Remote session failed");
 
         MutableCapabilities capabilities = new MutableCapabilities();
@@ -88,7 +88,7 @@ class PepeniumReportCollectorTest {
         assertEquals(7, report.totalEvents);
         assertEquals(1, report.failedAssertions);
         assertEquals("Assert secure area is visible", report.lastAssertion);
-        assertEquals("C:\\tmp\\manual.png", report.lastScreenshotPath);
+        assertTrue(report.lastScreenshotPath.contains("screenshots"));
         assertEquals(6, report.eventGroups.size());
         assertEquals(1, report.eventGroups.get(4).screenshots.size());
         assertEquals(4, report.keyEventCount);
@@ -97,6 +97,8 @@ class PepeniumReportCollectorTest {
         assertEquals("Open login page", report.flowBlocks.get(0).title);
         assertEquals("Submit credentials", report.flowBlocks.get(0).events.get(1).getMessage());
         assertNotNull(report.screenshotUri);
-        assertTrue(Files.exists(Path.of(URI.create(report.screenshotUri))));
+        assertTrue(report.screenshotUri.startsWith("screenshots/"));
+        assertTrue(Files.exists(reportDir.resolve(report.screenshotUri)));
+        assertTrue(Files.exists(Path.of(report.lastScreenshotPath)));
     }
 }


### PR DESCRIPTION
## Summary
- bundle manual timeline screenshots into the report `screenshots/` directory before rendering
- rewrite screenshot links to be report-relative when the assets live under the report folder
- cover the new behavior with report collector tests so remote artifacts like AWS Device Farm work reliably

## Validation
- `mvn -B -ntp -pl pepenium-core "-Dtest=PepeniumHtmlReportWriterTest,PepeniumReportCollectorTest,PepeniumReportIndexWriterTest" test`
- `mvn -q -DskipTests test-compile`
