### PR TITLE
Integrate pending config and reporting release changes

### DIFF
--- a/.env.web.capabilities.example
+++ b/.env.web.capabilities.example
@@ -1,0 +1,18 @@
+PEPENIUM_PROFILE=local-web
+PEPENIUM_BASE_URL=https://the-internet.herokuapp.com/login
+
+# Common desktop-web driver tuning
+# PEPENIUM_WEB_HEADLESS=true
+# PEPENIUM_WEB_ACCEPT_INSECURE_CERTS=true
+# PEPENIUM_WEB_PAGE_LOAD_STRATEGY=eager
+# PEPENIUM_WEB_BROWSER_VERSION=135
+# PEPENIUM_WEB_BINARY_PATH=C:\Program Files\Google\Chrome\Application\chrome.exe
+
+# Browser arguments are separated with ';'
+# PEPENIUM_WEB_ARGS=--incognito;--window-size=1920,1080
+
+# Arbitrary extra capabilities also use ';' and key=value format
+# PEPENIUM_WEB_CAPABILITIES=custom:flag=true;custom:retries=3
+
+# Observability
+# PEPENIUM_SCREENSHOT_PATH=C:\temp\pepenium-screenshots

--- a/.env.web.example
+++ b/.env.web.example
@@ -6,3 +6,4 @@ PEPENIUM_WEB_PASSWORD=SuperSecretPassword!
 # PEPENIUM_DETAIL_LOGGING=false
 # PEPENIUM_STEP_TRACKER_LIMIT=10
 # PEPENIUM_REPORT_DIR=target\pepenium-reports
+# For driver tuning, see .env.web.capabilities.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Added `PEPENIUM_SCREENSHOT_PATH` as the preferred screenshot output override while keeping `DEVICEFARM_SCREENSHOT_PATH` as a backward-compatible alias for existing and AWS Device Farm setups.
+- Improved driver-session observability by logging the effective sanitized capabilities sent to the driver layer and surfacing the same detail in automatic failure reporting.
 
 ### Improved
 - Improved screenshot diagnostics so failed capture logs now include the target output directory, making path and permissions issues easier to understand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 - Added richer `.env` example files and expanded configuration guidance so local web, local Android and Appium capability tuning are easier to bootstrap from documented templates.
+- Added optional `PEPENIUM_WEB_*` overrides for the built-in local desktop web profiles so Chrome, Firefox and Edge runs can be tuned from environment variables without custom driver config classes.
 
 ### Changed
 - Added `PEPENIUM_SCREENSHOT_PATH` as the preferred screenshot output override while keeping `DEVICEFARM_SCREENSHOT_PATH` as a backward-compatible alias for existing and AWS Device Farm setups.

--- a/README.es.md
+++ b/README.es.md
@@ -43,6 +43,7 @@ Ficheros de entorno listos para copiar:
 
 - [`.env.web.example`](.env.web.example)
 - [`.env.android.local.example`](.env.android.local.example)
+- [`.env.web.capabilities.example`](.env.web.capabilities.example)
 - [`.env.android.host-emulator.example`](.env.android.host-emulator.example)
 - [`.env.android.docker-emulator.example`](.env.android.docker-emulator.example)
 - [`.env.mobile.capabilities.example`](.env.mobile.capabilities.example)
@@ -57,7 +58,7 @@ Ficheros de entorno listos para copiar:
 - Logs mas limpios con contexto automatico y evidencia de fallo
 
 Consulta [START-HERE.es.md](docs/es/START-HERE.es.md) para el camino mas rapido al primer uso, [QUICK-START.es.md](docs/es/QUICK-START.es.md) para la guia mas completa y [CHANGELOG.md](CHANGELOG.md) para el historico de versiones.
-Usa [ENVIRONMENT.md](docs/ENVIRONMENT.md) como referencia central de variables de entorno, reglas de precedencia y puntos de partida listos para copiar.
+Usa [ENVIRONMENT.md](docs/ENVIRONMENT.md) como referencia central de variables de entorno, reglas de precedencia, properties de runtime y patrones de override de capabilities.
 Usa el `docker-compose.yaml` de la raiz si quieres ejecutar el servidor Appium local en Docker mientras el emulador Android sigue en el host.
 Usa [consumer-smoke/README.md](consumer-smoke/README.md) si quieres validar el consumo de la API publica desde un proyecto Maven separado.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Ready-to-copy environment examples:
 
 - [`.env.web.example`](.env.web.example)
 - [`.env.android.local.example`](.env.android.local.example)
+- [`.env.web.capabilities.example`](.env.web.capabilities.example)
 - [`.env.android.host-emulator.example`](.env.android.host-emulator.example)
 - [`.env.android.docker-emulator.example`](.env.android.docker-emulator.example)
 - [`.env.mobile.capabilities.example`](.env.mobile.capabilities.example)
@@ -58,6 +59,7 @@ Ready-to-copy environment examples:
 
 See [START-HERE.md](docs/START-HERE.md) for the fastest first-run path, [QUICK-START.md](docs/QUICK-START.md) for the fuller walkthrough and [CHANGELOG.md](CHANGELOG.md) for release history.
 Use [ENVIRONMENT.md](docs/ENVIRONMENT.md) as the central reference for environment variables, precedence rules and ready-to-copy configuration starting points.
+Use [ENVIRONMENT.md](docs/ENVIRONMENT.md) as the central reference for environment variables, precedence rules, runtime properties and capability override patterns.
 Use [API.md](docs/API.md) for the current public-vs-internal API guidance on the road to `1.0.0`.
 Use the root `docker-compose.yaml` if you want to run the local Appium server in Docker while keeping the Android emulator on the host.
 Use [consumer-smoke/README.md](consumer-smoke/README.md) for the standalone public-API consumer smoke validation flow.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -8,6 +8,7 @@ Ready-to-copy examples for common local setups:
 
 - [`.env.web.example`](../.env.web.example)
 - [`.env.android.local.example`](../.env.android.local.example)
+- [`.env.web.capabilities.example`](../.env.web.capabilities.example)
 - [`.env.android.host-emulator.example`](../.env.android.host-emulator.example)
 - [`.env.android.docker-emulator.example`](../.env.android.docker-emulator.example)
 - [`.env.mobile.capabilities.example`](../.env.mobile.capabilities.example)
@@ -183,6 +184,29 @@ They are intended for advanced mobile runs when the default Appium option sets n
   - Android web example
   - iOS web example
 - Purpose: Base URL opened by the example tests
+
+### Optional local desktop web capability overrides
+
+These optional environment variables are supported by the built-in local desktop web profiles:
+
+- `local-web`
+- `local-web-firefox`
+- `local-web-edge`
+
+- `PEPENIUM_WEB_HEADLESS`
+- `PEPENIUM_WEB_ACCEPT_INSECURE_CERTS`
+- `PEPENIUM_WEB_PAGE_LOAD_STRATEGY`
+- `PEPENIUM_WEB_BROWSER_VERSION`
+- `PEPENIUM_WEB_BINARY_PATH`
+- `PEPENIUM_WEB_ARGS`
+- `PEPENIUM_WEB_CAPABILITIES`
+
+Notes:
+
+- `PEPENIUM_WEB_ARGS` uses `;` as separator, for example `--incognito;--window-size=1920,1080`
+- `PEPENIUM_WEB_CAPABILITIES` also uses `;` and `key=value` entries, for example `custom:flag=true;custom:retries=3`
+- `PEPENIUM_WEB_HEADLESS=true` maps to the browser-specific headless argument for Chromium and Firefox
+- `PEPENIUM_WEB_PAGE_LOAD_STRATEGY` accepts `normal`, `eager` or `none`
 
 ## AWS Device Farm
 
@@ -385,7 +409,20 @@ APP_PATH=C:\apps\my-app.apk
 ### Local Desktop Web
 
 ```text
+PEPENIUM_PROFILE=local-web
 PEPENIUM_BASE_URL=https://example.com
+```
+
+### Local Desktop Web With Driver Tuning
+
+```text
+PEPENIUM_PROFILE=local-web
+PEPENIUM_BASE_URL=https://example.com
+PEPENIUM_WEB_HEADLESS=true
+PEPENIUM_WEB_ACCEPT_INSECURE_CERTS=true
+PEPENIUM_WEB_PAGE_LOAD_STRATEGY=eager
+PEPENIUM_WEB_ARGS=--incognito;--window-size=1920,1080
+PEPENIUM_WEB_CAPABILITIES=custom:flag=true;custom:retries=3
 ```
 
 ### Detailed Diagnostics

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverrides.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverrides.java
@@ -1,0 +1,213 @@
+package io.github.roberto22palomar.pepenium.core.config.validation;
+
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.remote.AbstractDriverOptions;
+
+import java.util.function.Function;
+
+public final class WebCapabilityOverrides {
+
+    private WebCapabilityOverrides() {
+    }
+
+    public static void applyChrome(Function<String, String> env, ChromeOptions options) {
+        applyCommon(env, options, BrowserKind.CHROMIUM);
+    }
+
+    public static void applyFirefox(Function<String, String> env, FirefoxOptions options) {
+        applyCommon(env, options, BrowserKind.FIREFOX);
+    }
+
+    public static void applyEdge(Function<String, String> env, EdgeOptions options) {
+        applyCommon(env, options, BrowserKind.CHROMIUM);
+    }
+
+    private static void applyCommon(Function<String, String> env,
+                                    AbstractDriverOptions<?> options,
+                                    BrowserKind browserKind) {
+        applyBoolean(env, "PEPENIUM_WEB_ACCEPT_INSECURE_CERTS", options::setAcceptInsecureCerts);
+        applyString(env, "PEPENIUM_WEB_BROWSER_VERSION", options::setBrowserVersion);
+        applyBinary(env, options, browserKind);
+        applyPageLoadStrategy(env, options);
+        applyArguments(env, options, browserKind);
+        applyHeadless(env, options, browserKind);
+        applyGenericCapabilities(env, options);
+    }
+
+    private static void applyPageLoadStrategy(Function<String, String> env, AbstractDriverOptions<?> options) {
+        String value = envValue(env, "PEPENIUM_WEB_PAGE_LOAD_STRATEGY");
+        if (value == null) {
+            return;
+        }
+        try {
+            options.setPageLoadStrategy(PageLoadStrategy.fromString(value));
+        } catch (RuntimeException ex) {
+            throw new IllegalStateException(
+                    "PEPENIUM_WEB_PAGE_LOAD_STRATEGY must be one of 'normal', 'eager' or 'none'.", ex);
+        }
+    }
+
+    private static void applyBinary(Function<String, String> env,
+                                    AbstractDriverOptions<?> options,
+                                    BrowserKind browserKind) {
+        String value = envValue(env, "PEPENIUM_WEB_BINARY_PATH");
+        if (value != null) {
+            browserKind.setBinary(options, value);
+        }
+    }
+
+    private static void applyArguments(Function<String, String> env,
+                                       AbstractDriverOptions<?> options,
+                                       BrowserKind browserKind) {
+        String value = envValue(env, "PEPENIUM_WEB_ARGS");
+        if (value == null) {
+            return;
+        }
+        for (String rawArg : value.split(";")) {
+            String arg = rawArg == null ? null : rawArg.trim();
+            if (arg == null || arg.isBlank()) {
+                continue;
+            }
+            browserKind.addArgument(options, arg);
+        }
+    }
+
+    private static void applyHeadless(Function<String, String> env,
+                                      AbstractDriverOptions<?> options,
+                                      BrowserKind browserKind) {
+        String value = envValue(env, "PEPENIUM_WEB_HEADLESS");
+        if (value == null || !parseBoolean("PEPENIUM_WEB_HEADLESS", value)) {
+            return;
+        }
+        browserKind.addHeadlessArgument(options);
+    }
+
+    private static void applyGenericCapabilities(Function<String, String> env, AbstractDriverOptions<?> options) {
+        String value = envValue(env, "PEPENIUM_WEB_CAPABILITIES");
+        if (value == null) {
+            return;
+        }
+        for (String rawEntry : value.split(";")) {
+            String entry = rawEntry == null ? null : rawEntry.trim();
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+            int separator = entry.indexOf('=');
+            if (separator <= 0 || separator == entry.length() - 1) {
+                throw new IllegalStateException(
+                        "PEPENIUM_WEB_CAPABILITIES entries must follow key=value format and be separated with ';'.");
+            }
+            String key = entry.substring(0, separator).trim();
+            String rawValue = entry.substring(separator + 1).trim();
+            if (key.isBlank() || rawValue.isBlank()) {
+                throw new IllegalStateException(
+                        "PEPENIUM_WEB_CAPABILITIES entries must follow key=value format and be separated with ';'.");
+            }
+            options.setCapability(key, parseScalar(rawValue));
+        }
+    }
+
+    private static void applyString(Function<String, String> env,
+                                    String key,
+                                    java.util.function.Consumer<String> setter) {
+        String value = envValue(env, key);
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+
+    private static void applyBoolean(Function<String, String> env,
+                                     String key,
+                                     java.util.function.Consumer<Boolean> setter) {
+        String value = envValue(env, key);
+        if (value != null) {
+            setter.accept(parseBoolean(key, value));
+        }
+    }
+
+    private static String envValue(Function<String, String> env, String key) {
+        String value = env.apply(key);
+        return (value == null || value.isBlank()) ? null : value.trim();
+    }
+
+    private static boolean parseBoolean(String key, String value) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        throw new IllegalStateException(key + " must be either 'true' or 'false'.");
+    }
+
+    private static Object parseScalar(String rawValue) {
+        String value = rawValue.trim();
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ignored) {
+        }
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ignored) {
+        }
+        return value;
+    }
+
+    private enum BrowserKind {
+        CHROMIUM {
+            @Override
+            void addArgument(AbstractDriverOptions<?> options, String argument) {
+                if (options instanceof ChromeOptions) {
+                    ((ChromeOptions) options).addArguments(argument);
+                    return;
+                }
+                ((EdgeOptions) options).addArguments(argument);
+            }
+
+            @Override
+            void addHeadlessArgument(AbstractDriverOptions<?> options) {
+                addArgument(options, "--headless=new");
+            }
+
+            @Override
+            void setBinary(AbstractDriverOptions<?> options, String binaryPath) {
+                if (options instanceof ChromeOptions) {
+                    ((ChromeOptions) options).setBinary(binaryPath);
+                    return;
+                }
+                ((EdgeOptions) options).setBinary(binaryPath);
+            }
+        },
+        FIREFOX {
+            @Override
+            void addArgument(AbstractDriverOptions<?> options, String argument) {
+                ((FirefoxOptions) options).addArguments(argument);
+            }
+
+            @Override
+            void addHeadlessArgument(AbstractDriverOptions<?> options) {
+                addArgument(options, "-headless");
+            }
+
+            @Override
+            void setBinary(AbstractDriverOptions<?> options, String binaryPath) {
+                ((FirefoxOptions) options).setBinary(binaryPath);
+            }
+        };
+
+        abstract void addArgument(AbstractDriverOptions<?> options, String argument);
+
+        abstract void addHeadlessArgument(AbstractDriverOptions<?> options);
+
+        abstract void setBinary(AbstractDriverOptions<?> options, String binaryPath);
+    }
+}

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/ChromeWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/ChromeWebConfigLocal.java
@@ -1,5 +1,6 @@
 package io.github.roberto22palomar.pepenium.core.configs.local.desktop;
 
+import io.github.roberto22palomar.pepenium.core.config.validation.WebCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -11,6 +12,7 @@ public class ChromeWebConfigLocal implements DriverConfig {
     public DriverRequest createRequest() {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("start-maximized");
+        WebCapabilityOverrides.applyChrome(System::getenv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_CHROME)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/EdgeWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/EdgeWebConfigLocal.java
@@ -1,5 +1,6 @@
 package io.github.roberto22palomar.pepenium.core.configs.local.desktop;
 
+import io.github.roberto22palomar.pepenium.core.config.validation.WebCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -11,6 +12,7 @@ public class EdgeWebConfigLocal implements DriverConfig {
     public DriverRequest createRequest() {
         EdgeOptions options = new EdgeOptions();
         options.addArguments("start-maximized");
+        WebCapabilityOverrides.applyEdge(System::getenv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_EDGE)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/FirefoxWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/FirefoxWebConfigLocal.java
@@ -1,5 +1,6 @@
 package io.github.roberto22palomar.pepenium.core.configs.local.desktop;
 
+import io.github.roberto22palomar.pepenium.core.config.validation.WebCapabilityOverrides;
 import io.github.roberto22palomar.pepenium.core.execution.DriverConfig;
 import io.github.roberto22palomar.pepenium.core.execution.DriverRequest;
 import io.github.roberto22palomar.pepenium.core.execution.DriverType;
@@ -12,6 +13,7 @@ public class FirefoxWebConfigLocal implements DriverConfig {
         FirefoxOptions options = new FirefoxOptions();
         options.addArguments("--width=1920");
         options.addArguments("--height=1080");
+        WebCapabilityOverrides.applyFirefox(System::getenv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_FIREFOX)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/CapabilitiesSummary.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/CapabilitiesSummary.java
@@ -2,9 +2,11 @@ package io.github.roberto22palomar.pepenium.core.observability;
 
 import org.openqa.selenium.Capabilities;
 
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.TreeMap;
 
 public final class CapabilitiesSummary {
 
@@ -49,5 +51,42 @@ public final class CapabilitiesSummary {
         StringJoiner joiner = new StringJoiner(", ");
         selected.forEach((key, value) -> joiner.add(key + "=" + value));
         return joiner.toString();
+    }
+
+    public static String describe(Capabilities capabilities) {
+        if (capabilities == null) {
+            return "none";
+        }
+
+        Map<String, Object> all = capabilities.asMap();
+        if (all.isEmpty()) {
+            return "present";
+        }
+
+        Map<String, Object> ordered = new TreeMap<>(Comparator.naturalOrder());
+        all.forEach((key, value) -> ordered.put(key, sanitizeValue(key, value)));
+
+        StringJoiner joiner = new StringJoiner(", ");
+        ordered.forEach((key, value) -> joiner.add(key + "=" + value));
+        return joiner.toString();
+    }
+
+    private static Object sanitizeValue(String key, Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (isSensitiveKey(key)) {
+            return "***";
+        }
+        return value;
+    }
+
+    private static boolean isSensitiveKey(String key) {
+        String normalized = key == null ? "" : key.toLowerCase();
+        return normalized.contains("accesskey")
+                || normalized.contains("password")
+                || normalized.contains("secret")
+                || normalized.contains("token")
+                || normalized.contains("apikey");
     }
 }

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporter.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporter.java
@@ -42,7 +42,8 @@ public final class FailureContextReporter {
                 request.getExecutionProfileId(),
                 request.getDriverType());
         logSteps();
-        log.error("Capabilities: {}", CapabilitiesSummary.summarize(request.getCapabilities()));
+        log.error("Capabilities summary: {}", CapabilitiesSummary.summarize(request.getCapabilities()));
+        log.error("Effective capabilities: {}", CapabilitiesSummary.describe(request.getCapabilities()));
         LoggingPreferences.logDetail(log, "Detailed failure stacktrace", cause);
 
         logScreenshot(driver);

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumHtmlReportWriter.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumHtmlReportWriter.java
@@ -245,6 +245,7 @@ public final class PepeniumHtmlReportWriter {
         final String mobilePackage;
         final String mobileActivity;
         final DeviceContext deviceContext;
+        final Path reportDir;
         final String capabilitiesSummary;
         final StepTracker.Snapshot stepSnapshot;
         final PepeniumTimeline.Snapshot timelineSnapshot;
@@ -287,6 +288,7 @@ public final class PepeniumHtmlReportWriter {
                 String mobilePackage,
                 String mobileActivity,
                 DeviceContext deviceContext,
+                Path reportDir,
                 String capabilitiesSummary,
                 StepTracker.Snapshot stepSnapshot,
                 PepeniumTimeline.Snapshot timelineSnapshot,
@@ -328,6 +330,7 @@ public final class PepeniumHtmlReportWriter {
             this.mobilePackage = mobilePackage;
             this.mobileActivity = mobileActivity;
             this.deviceContext = deviceContext;
+            this.reportDir = reportDir;
             this.capabilitiesSummary = capabilitiesSummary;
             this.stepSnapshot = stepSnapshot;
             this.timelineSnapshot = timelineSnapshot;

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollector.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollector.java
@@ -23,7 +23,10 @@ final class PepeniumReportCollector {
     static PepeniumHtmlReportWriter.ReportContext collect(String testName, DriverSession session, Throwable cause, Path reportDir) {
         Instant finishedAt = Instant.now();
         StepTracker.Snapshot stepSnapshot = StepTracker.snapshot();
-        PepeniumTimeline.Snapshot timelineSnapshot = PepeniumTimeline.snapshot();
+        PepeniumTimeline.Snapshot timelineSnapshot = PepeniumTimeline.remapScreenshotPaths(
+                PepeniumTimeline.snapshot(),
+                screenshotPath -> PepeniumReportSupport.bundleScreenshotArtifact(screenshotPath, reportDir)
+        );
         DriverRequest request = session == null ? null : session.getRequest();
         WebDriver driver = session == null ? null : session.getDriver();
         String outcome = cause == null ? "PASSED" : "FAILED";
@@ -50,6 +53,7 @@ final class PepeniumReportCollector {
                 PepeniumReportSupport.safe(PepeniumReportSupport.mobilePackage(driver)),
                 PepeniumReportSupport.safe(PepeniumReportSupport.mobileActivity(driver)),
                 deviceContext,
+                reportDir,
                 PepeniumReportSupport.safe(CapabilitiesSummary.summarize(request == null ? null : request.getCapabilities())),
                 stepSnapshot,
                 timelineSnapshot,

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportHtmlRenderer.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportHtmlRenderer.java
@@ -97,14 +97,14 @@ final class PepeniumReportHtmlRenderer {
             html.append("<div class=\"timeline-preview\">");
             int previewCount = Math.min(5, keyTimelineEvents.size());
             for (int i = 0; i < previewCount; i++) {
-                html.append(renderTimelineCard(keyTimelineEvents.get(i), report.startedAt, null));
+                html.append(renderTimelineCard(keyTimelineEvents.get(i), report.startedAt, null, report.reportDir));
             }
             html.append("</div>");
             if (keyTimelineEvents.size() > previewCount) {
                 html.append("<details class=\"more-link\"><summary>View more key events (")
                         .append(keyTimelineEvents.size() - previewCount).append(" more)</summary><div class=\"timeline\" style=\"margin-top:12px;\">");
                 for (int i = previewCount; i < keyTimelineEvents.size(); i++) {
-                    html.append(renderTimelineCard(keyTimelineEvents.get(i), report.startedAt, null));
+                    html.append(renderTimelineCard(keyTimelineEvents.get(i), report.startedAt, null, report.reportDir));
                 }
                 html.append("</div></details>");
             }
@@ -146,7 +146,7 @@ final class PepeniumReportHtmlRenderer {
             html.append("<div class=\"empty\">No timeline events were recorded for this test.</div>");
         } else {
             for (PepeniumHtmlReportWriter.EventGroup group : report.eventGroups) {
-                html.append(renderTimelineCard(group.anchorEvent, report.startedAt, group));
+                html.append(renderTimelineCard(group.anchorEvent, report.startedAt, group, report.reportDir));
             }
         }
         html.append("</div></details></div></section>");
@@ -205,7 +205,7 @@ final class PepeniumReportHtmlRenderer {
             html.append(renderArtifactLink("Final screenshot", report.screenshotUri));
         }
         if (report.lastScreenshotPath != null) {
-            html.append(renderArtifactLink("Last manual screenshot", PepeniumReportSupport.pathToUri(report.lastScreenshotPath)));
+            html.append(renderArtifactLink("Last manual screenshot", PepeniumReportSupport.pathToHref(report.lastScreenshotPath, report.reportDir)));
         }
         if (report.remoteContext.enabled && report.remoteContext.dashboardUrl != null) {
             html.append(renderArtifactLink("Remote dashboard", report.remoteContext.dashboardUrl));
@@ -310,7 +310,8 @@ final class PepeniumReportHtmlRenderer {
     }
 
     private static String renderTimelineCard(PepeniumTimeline.Event anchor, Instant startedAt,
-                                             PepeniumHtmlReportWriter.EventGroup group) {
+                                             PepeniumHtmlReportWriter.EventGroup group,
+                                             java.nio.file.Path reportDir) {
         StringBuilder html = new StringBuilder();
         html.append("<article class=\"timeline-card ")
                 .append(timelineCardClass(anchor))
@@ -330,7 +331,7 @@ final class PepeniumReportHtmlRenderer {
                     .append(group.screenshots.size() == 1 ? " screenshot" : " screenshots")
                     .append("</summary><div class=\"attachments\">");
             for (PepeniumTimeline.Event screenshot : group.screenshots) {
-                String screenshotUri = PepeniumReportSupport.pathToUri(screenshot.getScreenshotPath());
+                String screenshotUri = PepeniumReportSupport.pathToHref(screenshot.getScreenshotPath(), reportDir);
                 html.append("<div class=\"attachment\"><div>")
                         .append(renderEventTypeBadge(screenshot))
                         .append("<span class=\"timeline-time\">").append(PepeniumReportSupport.escapeHtml(screenshot.getTime())).append("</span></div>")

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
@@ -144,6 +144,9 @@ final class PepeniumReportSupport {
         if (originalPath == null || originalPath.isBlank()) {
             return null;
         }
+        if (reportDir == null) {
+            return originalPath;
+        }
         try {
             Path source = Path.of(originalPath).normalize();
             if (!Files.exists(source) || Files.isDirectory(source)) {

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
@@ -15,6 +15,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -133,14 +134,50 @@ final class PepeniumReportSupport {
             Files.createDirectories(screenshotDir);
             Path screenshotPath = screenshotDir.resolve("report_" + Instant.now().toEpochMilli() + ".png");
             Files.write(screenshotPath, screenshot);
-            return screenshotPath.toUri().toString();
+            return pathToHref(screenshotPath.toString(), reportDir);
         } catch (Exception e) {
             return null;
         }
     }
 
-    static String pathToUri(String path) {
-        return path == null ? null : Path.of(path).toUri().toString();
+    static String bundleScreenshotArtifact(String originalPath, Path reportDir) {
+        if (originalPath == null || originalPath.isBlank()) {
+            return null;
+        }
+        try {
+            Path source = Path.of(originalPath).normalize();
+            if (!Files.exists(source) || Files.isDirectory(source)) {
+                return originalPath;
+            }
+            Path screenshotDir = reportDir.resolve("screenshots");
+            Files.createDirectories(screenshotDir);
+            String fileName = source.getFileName() == null ? "manual.png" : source.getFileName().toString();
+            Path target = screenshotDir.resolve("manual_" + Instant.now().toEpochMilli() + "_" + fileName).normalize();
+            if (!source.equals(target)) {
+                Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+            return target.toString();
+        } catch (Exception ignored) {
+            return originalPath;
+        }
+    }
+
+    static String pathToHref(String path, Path reportDir) {
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+        try {
+            Path resolved = Path.of(path).normalize();
+            if (reportDir != null && resolved.isAbsolute()) {
+                Path normalizedReportDir = reportDir.toAbsolutePath().normalize();
+                if (resolved.startsWith(normalizedReportDir)) {
+                    return normalizedReportDir.relativize(resolved).toString().replace('\\', '/');
+                }
+            }
+            return resolved.isAbsolute() ? resolved.toUri().toString() : resolved.toString().replace('\\', '/');
+        } catch (Exception ignored) {
+            return path;
+        }
     }
 
     static Path resolveReportDir() {

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportSupport.java
@@ -154,7 +154,11 @@ final class PepeniumReportSupport {
             }
             Path screenshotDir = reportDir.resolve("screenshots");
             Files.createDirectories(screenshotDir);
-            String fileName = source.getFileName() == null ? "manual.png" : source.getFileName().toString();
+            Path fileNamePath = source.getFileName();
+            String fileName = "manual.png";
+            if (fileNamePath != null) {
+                fileName = fileNamePath.toString();
+            }
             Path target = screenshotDir.resolve("manual_" + Instant.now().toEpochMilli() + "_" + fileName).normalize();
             if (!source.equals(target)) {
                 Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumTimeline.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumTimeline.java
@@ -6,6 +6,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 public final class PepeniumTimeline {
 
@@ -56,6 +57,25 @@ public final class PepeniumTimeline {
     public static void clear() {
         EVENTS.remove();
         STARTED_AT.remove();
+    }
+
+    static Snapshot remapScreenshotPaths(Snapshot snapshot, Function<String, String> mapper) {
+        List<Event> remapped = new ArrayList<>();
+        for (Event event : snapshot.getEvents()) {
+            String screenshotPath = event.getScreenshotPath();
+            if (screenshotPath != null) {
+                screenshotPath = mapper.apply(screenshotPath);
+            }
+            remapped.add(new Event(
+                    event.getEpochMillis(),
+                    event.getTime(),
+                    event.getType(),
+                    event.getStatus(),
+                    event.getMessage(),
+                    screenshotPath
+            ));
+        }
+        return new Snapshot(remapped, snapshot.getStartedAt());
     }
 
     private static void record(EventType type, EventStatus status, String message, String screenshotPath) {

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/runtime/DefaultDriverSessionFactory.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/runtime/DefaultDriverSessionFactory.java
@@ -31,6 +31,10 @@ public class DefaultDriverSessionFactory implements DriverSessionFactory {
         log.info("Creating driver session: description='{}', capabilities={}",
                 request.getDescription(),
                 CapabilitiesSummary.summarize(request.getCapabilities()));
+        if (request.getServerUrl() != null) {
+            log.info("Driver server: {}", sanitizeServerUrl(request.getServerUrl()));
+        }
+        log.info("Effective capabilities: {}", CapabilitiesSummary.describe(request.getCapabilities()));
         WebDriver driver;
 
         switch (request.getDriverType()) {
@@ -61,6 +65,18 @@ public class DefaultDriverSessionFactory implements DriverSessionFactory {
         log.info("Driver session created successfully");
 
         return new DriverSession(driver, request);
+    }
+
+    private String sanitizeServerUrl(URL url) {
+        if (url == null) {
+            return "none";
+        }
+        String userInfo = url.getUserInfo();
+        if (userInfo == null || userInfo.isBlank()) {
+            return url.toString();
+        }
+        String raw = url.toString();
+        return raw.replace(userInfo + "@", "***@");
     }
 
     private URL requireServerUrl(DriverRequest request) {

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverridesTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverridesTest.java
@@ -1,0 +1,94 @@
+package io.github.roberto22palomar.pepenium.core.config.validation;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebCapabilityOverridesTest {
+
+    @Test
+    void applyChromeSupportsHeadlessArgsAndGenericCapabilities() {
+        ChromeOptions options = new ChromeOptions();
+
+        WebCapabilityOverrides.applyChrome(Map.of(
+                "PEPENIUM_WEB_HEADLESS", "true",
+                "PEPENIUM_WEB_ACCEPT_INSECURE_CERTS", "true",
+                "PEPENIUM_WEB_PAGE_LOAD_STRATEGY", "eager",
+                "PEPENIUM_WEB_ARGS", "--incognito;--window-size=1920,1080",
+                "PEPENIUM_WEB_CAPABILITIES", "custom:flag=true;custom:retries=3;custom:ratio=1.5"
+        )::get, options);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> chromeOptions = (Map<String, Object>) options.getCapability("goog:chromeOptions");
+        assertTrue(((java.util.List<String>) chromeOptions.get("args")).contains("--headless=new"));
+        assertTrue(((java.util.List<String>) chromeOptions.get("args")).contains("--incognito"));
+        assertTrue(((java.util.List<String>) chromeOptions.get("args")).contains("--window-size=1920,1080"));
+        assertEquals(Boolean.TRUE, options.getCapability("acceptInsecureCerts"));
+        assertEquals(PageLoadStrategy.EAGER, options.getCapability("pageLoadStrategy"));
+        assertEquals(Boolean.TRUE, options.getCapability("custom:flag"));
+        assertEquals(3L, options.getCapability("custom:retries"));
+        assertEquals(1.5d, options.getCapability("custom:ratio"));
+    }
+
+    @Test
+    void applyFirefoxSupportsBinaryAndHeadless() {
+        FirefoxOptions options = new FirefoxOptions();
+
+        WebCapabilityOverrides.applyFirefox(Map.of(
+                "PEPENIUM_WEB_HEADLESS", "true",
+                "PEPENIUM_WEB_BINARY_PATH", "C:\\firefox\\firefox.exe"
+        )::get, options);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> firefoxOptions = (Map<String, Object>) options.getCapability("moz:firefoxOptions");
+        assertTrue(((java.util.List<String>) firefoxOptions.get("args")).contains("-headless"));
+        assertEquals("C:\\firefox\\firefox.exe", firefoxOptions.get("binary"));
+    }
+
+    @Test
+    void applyEdgeSupportsArgsAndBrowserVersion() {
+        EdgeOptions options = new EdgeOptions();
+
+        WebCapabilityOverrides.applyEdge(Map.of(
+                "PEPENIUM_WEB_ARGS", "--inprivate",
+                "PEPENIUM_WEB_BROWSER_VERSION", "135"
+        )::get, options);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> edgeOptions = (Map<String, Object>) options.getCapability("ms:edgeOptions");
+        assertTrue(((java.util.List<String>) edgeOptions.get("args")).contains("--inprivate"));
+        assertEquals("135", options.getBrowserVersion());
+    }
+
+    @Test
+    void applyThrowsOnInvalidBoolean() {
+        ChromeOptions options = new ChromeOptions();
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> WebCapabilityOverrides.applyChrome(Map.of("PEPENIUM_WEB_HEADLESS", "maybe")::get, options));
+
+        assertEquals("PEPENIUM_WEB_HEADLESS must be either 'true' or 'false'.", error.getMessage());
+    }
+
+    @Test
+    void applyThrowsOnMalformedCapabilitiesList() {
+        ChromeOptions options = new ChromeOptions();
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> WebCapabilityOverrides.applyChrome(
+                        Map.of("PEPENIUM_WEB_CAPABILITIES", "bad-entry")::get,
+                        options));
+
+        assertEquals(
+                "PEPENIUM_WEB_CAPABILITIES entries must follow key=value format and be separated with ';'.",
+                error.getMessage());
+    }
+}

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/CapabilitiesSummaryTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/CapabilitiesSummaryTest.java
@@ -1,0 +1,45 @@
+package io.github.roberto22palomar.pepenium.core.observability;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.MutableCapabilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CapabilitiesSummaryTest {
+
+    @Test
+    void summarizeUsesFocusedKeysWhenPresent() {
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("platformName", "Android");
+        capabilities.setCapability("appium:deviceName", "Pixel 9");
+        capabilities.setCapability("appium:appPackage", "io.github.example");
+        capabilities.setCapability("customCapability", "ignored");
+
+        String summary = CapabilitiesSummary.summarize(capabilities);
+
+        assertEquals(
+                "platformName=ANDROID, appium:deviceName=Pixel 9, appium:appPackage=io.github.example",
+                summary
+        );
+    }
+
+    @Test
+    void describeIncludesAllCapabilitiesInStableOrderAndRedactsSensitiveValues() {
+        MutableCapabilities capabilities = new MutableCapabilities();
+        capabilities.setCapability("bstack:options", "{deviceName=Pixel 9}");
+        capabilities.setCapability("platformName", "Android");
+        capabilities.setCapability("password", "super-secret");
+        capabilities.setCapability("accessKey", "abc123");
+
+        String description = CapabilitiesSummary.describe(capabilities);
+
+        assertTrue(description.contains("accessKey=***"));
+        assertTrue(description.contains("password=***"));
+        assertTrue(description.contains("platformName=ANDROID"));
+        assertTrue(description.contains("bstack:options={deviceName=Pixel 9}"));
+        assertTrue(description.indexOf("accessKey=***") < description.indexOf("platformName=ANDROID"));
+        assertTrue(description.indexOf("bstack:options={deviceName=Pixel 9}") < description.indexOf("platformName=ANDROID"));
+        assertTrue(description.indexOf("password=***") < description.indexOf("platformName=ANDROID"));
+    }
+}

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporterTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/FailureContextReporterTest.java
@@ -109,7 +109,8 @@ class FailureContextReporterTest {
         assertTrue(appender.contains("Failure summary for 'webFailure': IllegalArgumentException - Broken field"));
         assertTrue(appender.contains("Recent steps"));
         assertTrue(appender.contains("Step:"));
-        assertTrue(appender.contains("Capabilities: browserName=chrome"));
+        assertTrue(appender.contains("Capabilities summary: browserName=chrome"));
+        assertTrue(appender.contains("Effective capabilities: browserName=chrome"));
         assertTrue(appender.contains("Session: abcdef123456"));
         assertTrue(appender.contains("Web: url='https://example.test/login', title='Example'"));
     }

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollectorTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollectorTest.java
@@ -15,7 +15,6 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.remote.SessionId;
 
-import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,12 +41,13 @@ class PepeniumReportCollectorTest {
 
     @Test
     void collectCapturesRemoteContextTimelineAndScreenshotArtifacts() throws Exception {
+        Path manualScreenshot = Files.write(reportDir.resolve("manual-source.png"), new byte[]{9, 8, 7});
         StepTracker.record("Open login page");
         PepeniumTimeline.recordAction("Submit credentials");
         PepeniumTimeline.recordWait("Wait for secure area");
         PepeniumTimeline.recordWait("Wait for secure area");
         PepeniumTimeline.recordAssertionFailed("Assert secure area is visible");
-        PepeniumTimeline.recordScreenshot("Manual screenshot", "C:\\tmp\\manual.png");
+        PepeniumTimeline.recordScreenshot("Manual screenshot", manualScreenshot.toString());
         PepeniumTimeline.recordError("Remote session failed");
 
         MutableCapabilities capabilities = new MutableCapabilities();
@@ -88,7 +88,7 @@ class PepeniumReportCollectorTest {
         assertEquals(7, report.totalEvents);
         assertEquals(1, report.failedAssertions);
         assertEquals("Assert secure area is visible", report.lastAssertion);
-        assertEquals("C:\\tmp\\manual.png", report.lastScreenshotPath);
+        assertTrue(report.lastScreenshotPath.contains("screenshots"));
         assertEquals(6, report.eventGroups.size());
         assertEquals(1, report.eventGroups.get(4).screenshots.size());
         assertEquals(4, report.keyEventCount);
@@ -97,6 +97,8 @@ class PepeniumReportCollectorTest {
         assertEquals("Open login page", report.flowBlocks.get(0).title);
         assertEquals("Submit credentials", report.flowBlocks.get(0).events.get(1).getMessage());
         assertNotNull(report.screenshotUri);
-        assertTrue(Files.exists(Path.of(URI.create(report.screenshotUri))));
+        assertTrue(report.screenshotUri.startsWith("screenshots/"));
+        assertTrue(Files.exists(reportDir.resolve(report.screenshotUri)));
+        assertTrue(Files.exists(Path.of(report.lastScreenshotPath)));
     }
 }


### PR DESCRIPTION
## Summary
- integrate the effective capability/session observability improvements from the pending work
- add the local desktop web capability override support and documentation/examples
- bring in the report screenshot artifact bundling so AWS/downloaded reports keep working links

## Notes
- local Android/Appium capability override support was already effectively present on `main` through newer integrated changes, so it was not re-applied from PR #123 to avoid duplicating stale conflicts
- this batch replaces merging #125, #128 and #130 separately for the release train

## Validation
- `mvn -B -ntp -pl pepenium-core "-Dtest=CapabilitiesSummaryTest,FailureContextReporterTest,WebCapabilityOverridesTest,PepeniumHtmlReportWriterTest,PepeniumReportCollectorTest,PepeniumReportIndexWriterTest" test`
- `mvn -q -DskipTests test-compile`
