### PR TITLE
Prepare 0.9.7 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.7] - 2026-04-07
+
 ### Added
 - Added richer `.env` example files and expanded configuration guidance so local web, local Android and Appium capability tuning are easier to bootstrap from documented templates.
 - Added optional `PEPENIUM_WEB_*` overrides for the built-in local desktop web profiles so Chrome, Firefox and Edge runs can be tuned from environment variables without custom driver config classes.

--- a/README.es.md
+++ b/README.es.md
@@ -85,7 +85,7 @@ Dependencia tipica de consumo:
 <dependency>
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-toolkit</artifactId>
-    <version>0.9.6</version>
+    <version>0.9.7</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Typical consumer dependency:
 <dependency>
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-toolkit</artifactId>
-    <version>0.9.6</version>
+    <version>0.9.7</version>
 </dependency>
 ```
 

--- a/consumer-smoke/README.md
+++ b/consumer-smoke/README.md
@@ -21,7 +21,7 @@ mvn -q -f consumer-smoke/pom.xml clean test-compile
 If needed, the consumed version can be overridden:
 
 ```bash
-mvn -q -f consumer-smoke/pom.xml clean test-compile -Dpepenium.version=0.9.6
+mvn -q -f consumer-smoke/pom.xml clean test-compile -Dpepenium.version=0.9.7
 ```
 
 ## What It Covers

--- a/consumer-smoke/pom.xml
+++ b/consumer-smoke/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <pepenium.version>0.9.6</pepenium.version>
+        <pepenium.version>0.9.7</pepenium.version>
         <junit.jupiter.version>5.13.1</junit.jupiter.version>
     </properties>
 

--- a/pepenium-core/pom.xml
+++ b/pepenium-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.6</version>
+        <version>0.9.7</version>
     </parent>
 
     <artifactId>pepenium</artifactId>

--- a/pepenium-examples/pom.xml
+++ b/pepenium-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.6</version>
+        <version>0.9.7</version>
     </parent>
 
     <artifactId>pepenium-examples</artifactId>

--- a/pepenium-toolkit/pom.xml
+++ b/pepenium-toolkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.6</version>
+        <version>0.9.7</version>
     </parent>
 
     <artifactId>pepenium-toolkit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-parent</artifactId>
-    <version>0.9.6</version>
+    <version>0.9.7</version>
     <packaging>pom</packaging>
     <name>Pepenium</name>
     <description>Java automation framework for Android, iOS and Web built on Appium, Selenium and JUnit 5.</description>
@@ -70,7 +70,7 @@
         <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
         <jacoco.maven.plugin.version>0.8.12</jacoco.maven.plugin.version>
         <japicmp.maven.plugin.version>0.25.4</japicmp.maven.plugin.version>
-        <public.api.compatibility.baseline.version>0.9.5</public.api.compatibility.baseline.version>
+        <public.api.compatibility.baseline.version>0.9.6</public.api.compatibility.baseline.version>
         <spotbugs.maven.plugin.version>4.8.6.6</spotbugs.maven.plugin.version>
         <checkstyle.version>10.18.2</checkstyle.version>
         <central.publishing.maven.plugin.version>0.9.0</central.publishing.maven.plugin.version>


### PR DESCRIPTION
## Summary
- bump the project version from `0.9.6` to `0.9.7`
- move the accumulated release notes into the `0.9.7` changelog section
- align consumer-smoke and README dependency examples with the new release version
- update the public API compatibility baseline to `0.9.6`

## Validation
- `mvn -q -DskipTests test-compile`
