### PR TITLE
Resolve local web overrides from system properties

### DIFF
--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverrides.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverrides.java
@@ -6,6 +6,7 @@ import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.AbstractDriverOptions;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 public final class WebCapabilityOverrides {
@@ -23,6 +24,17 @@ public final class WebCapabilityOverrides {
 
     public static void applyEdge(Function<String, String> env, EdgeOptions options) {
         applyCommon(env, options, BrowserKind.CHROMIUM);
+    }
+
+    public static String systemPropertyOrEnv(String key) {
+        String value = System.getProperty(toSystemPropertyKey(key));
+        if (value == null || value.isBlank()) {
+            value = System.getProperty(key);
+        }
+        if (value == null || value.isBlank()) {
+            value = System.getenv(key);
+        }
+        return value;
     }
 
     private static void applyCommon(Function<String, String> env,
@@ -131,6 +143,10 @@ public final class WebCapabilityOverrides {
     private static String envValue(Function<String, String> env, String key) {
         String value = env.apply(key);
         return (value == null || value.isBlank()) ? null : value.trim();
+    }
+
+    private static String toSystemPropertyKey(String envKey) {
+        return envKey.toLowerCase(Locale.ROOT).replace('_', '.');
     }
 
     private static boolean parseBoolean(String key, String value) {

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/ChromeWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/ChromeWebConfigLocal.java
@@ -12,7 +12,7 @@ public class ChromeWebConfigLocal implements DriverConfig {
     public DriverRequest createRequest() {
         ChromeOptions options = new ChromeOptions();
         options.addArguments("start-maximized");
-        WebCapabilityOverrides.applyChrome(System::getenv, options);
+        WebCapabilityOverrides.applyChrome(WebCapabilityOverrides::systemPropertyOrEnv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_CHROME)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/EdgeWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/EdgeWebConfigLocal.java
@@ -12,7 +12,7 @@ public class EdgeWebConfigLocal implements DriverConfig {
     public DriverRequest createRequest() {
         EdgeOptions options = new EdgeOptions();
         options.addArguments("start-maximized");
-        WebCapabilityOverrides.applyEdge(System::getenv, options);
+        WebCapabilityOverrides.applyEdge(WebCapabilityOverrides::systemPropertyOrEnv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_EDGE)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/FirefoxWebConfigLocal.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/configs/local/desktop/FirefoxWebConfigLocal.java
@@ -13,7 +13,7 @@ public class FirefoxWebConfigLocal implements DriverConfig {
         FirefoxOptions options = new FirefoxOptions();
         options.addArguments("--width=1920");
         options.addArguments("--height=1080");
-        WebCapabilityOverrides.applyFirefox(System::getenv, options);
+        WebCapabilityOverrides.applyFirefox(WebCapabilityOverrides::systemPropertyOrEnv, options);
 
         return DriverRequest.builder()
                 .driverType(DriverType.LOCAL_FIREFOX)

--- a/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportHtmlRenderer.java
+++ b/pepenium-core/src/main/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportHtmlRenderer.java
@@ -2,6 +2,10 @@ package io.github.roberto22palomar.pepenium.core.observability;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 final class PepeniumReportHtmlRenderer {
 
@@ -198,6 +202,8 @@ final class PepeniumReportHtmlRenderer {
                     .append("</div></div></section>");
         }
 
+        List<String> manualScreenshotHrefs = manualScreenshotHrefs(report);
+
         html.append("<section class=\"section\"><h2>Artifacts</h2><div class=\"artifact-card\"><div class=\"artifact-list\">")
                 .append(renderArtifactLink("Suite index", "index.html"))
                 .append(renderArtifactLink("Suite summary JSON", "summary.json"));
@@ -211,6 +217,16 @@ final class PepeniumReportHtmlRenderer {
             html.append(renderArtifactLink("Remote dashboard", report.remoteContext.dashboardUrl));
         }
         html.append("</div></div></section>");
+
+        if (!manualScreenshotHrefs.isEmpty()) {
+            html.append("<section class=\"section\"><h2>Screenshots</h2><div class=\"artifact-card\"><div class=\"attachments\">");
+            int screenshotNumber = 1;
+            for (String screenshotHref : manualScreenshotHrefs) {
+                html.append(renderScreenshotAttachment("Screenshot " + screenshotNumber, screenshotHref));
+                screenshotNumber++;
+            }
+            html.append("</div></div></section>");
+        }
 
         if (report.screenshotUri != null) {
             html.append("<section class=\"section\"><h2>Final Screenshot</h2><div class=\"artifact-card\"><a href=\"")
@@ -249,6 +265,15 @@ final class PepeniumReportHtmlRenderer {
     private static String renderArtifactLink(String label, String href) {
         return "<a class=\"artifact-link\" href=\"" + PepeniumReportSupport.escapeHtml(PepeniumReportSupport.defaultValue(href))
                 + "\"><span>" + PepeniumReportSupport.escapeHtml(label) + "</span><span class=\"muted\">Open</span></a>";
+    }
+
+    private static String renderScreenshotAttachment(String label, String href) {
+        String safeHref = PepeniumReportSupport.escapeHtml(PepeniumReportSupport.defaultValue(href));
+        return "<div class=\"attachment\"><div><span class=\"badge badge-screenshot\">SCREENSHOT</span></div>"
+                + "<div class=\"timeline-message\">" + PepeniumReportSupport.escapeHtml(label) + "</div>"
+                + "<a href=\"" + safeHref + "\">Open screenshot</a>"
+                + "<img class=\"thumb\" src=\"" + safeHref + "\" alt=\"" + PepeniumReportSupport.escapeHtml(label) + "\">"
+                + "<div class=\"path\">" + safeHref + "</div></div>";
     }
 
     private static String renderFocusItem(String label, String value) {
@@ -344,6 +369,19 @@ final class PepeniumReportHtmlRenderer {
         }
         html.append("</article>");
         return html.toString();
+    }
+
+    private static List<String> manualScreenshotHrefs(PepeniumHtmlReportWriter.ReportContext report) {
+        Set<String> hrefs = new LinkedHashSet<>();
+        for (PepeniumHtmlReportWriter.EventGroup group : report.eventGroups) {
+            for (PepeniumTimeline.Event screenshot : group.screenshots) {
+                String screenshotHref = PepeniumReportSupport.pathToHref(screenshot.getScreenshotPath(), report.reportDir);
+                if (screenshotHref != null && !screenshotHref.isBlank()) {
+                    hrefs.add(screenshotHref);
+                }
+            }
+        }
+        return new ArrayList<>(hrefs);
     }
 
     private static String renderChip(String value) {

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverridesTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/config/validation/WebCapabilityOverridesTest.java
@@ -39,6 +39,22 @@ class WebCapabilityOverridesTest {
     }
 
     @Test
+    void applyChromeSupportsHeadlessFromSystemProperty() {
+        System.setProperty("pepenium.web.headless", "true");
+        try {
+            ChromeOptions options = new ChromeOptions();
+
+            WebCapabilityOverrides.applyChrome(WebCapabilityOverrides::systemPropertyOrEnv, options);
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> chromeOptions = (Map<String, Object>) options.getCapability("goog:chromeOptions");
+            assertTrue(((java.util.List<String>) chromeOptions.get("args")).contains("--headless=new"));
+        } finally {
+            System.clearProperty("pepenium.web.headless");
+        }
+    }
+
+    @Test
     void applyFirefoxSupportsBinaryAndHeadless() {
         FirefoxOptions options = new FirefoxOptions();
 

--- a/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollectorTest.java
+++ b/pepenium-core/src/test/java/io/github/roberto22palomar/pepenium/core/observability/PepeniumReportCollectorTest.java
@@ -101,4 +101,41 @@ class PepeniumReportCollectorTest {
         assertTrue(Files.exists(reportDir.resolve(report.screenshotUri)));
         assertTrue(Files.exists(Path.of(report.lastScreenshotPath)));
     }
+
+    @Test
+    void htmlReportRendersAllManualScreenshotsAsVisibleArtifacts() throws Exception {
+        Path firstScreenshot = Files.write(reportDir.resolve("first-source.png"), new byte[]{4, 5, 6});
+        Path secondScreenshot = Files.write(reportDir.resolve("second-source.png"), new byte[]{7, 8, 9});
+        StepTracker.record("Open dashboard");
+        PepeniumTimeline.recordScreenshot("First screenshot", firstScreenshot.toString());
+        StepTracker.record("Open detail");
+        PepeniumTimeline.recordScreenshot("Second screenshot", secondScreenshot.toString());
+
+        DriverRequest request = DriverRequest.builder()
+                .driverType(DriverType.LOCAL_CHROME)
+                .target(TestTarget.WEB_DESKTOP)
+                .description("local web")
+                .executionProfileId("local-web")
+                .capabilities(new MutableCapabilities())
+                .build();
+        when(driver.getScreenshotAs(OutputType.BYTES)).thenReturn(new byte[]{1, 2, 3});
+        when(driver.getSessionId()).thenReturn(new SessionId("session-654321"));
+        when(driver.getCurrentUrl()).thenReturn("https://example.test/dashboard");
+        when(driver.getTitle()).thenReturn("Dashboard");
+
+        PepeniumHtmlReportWriter.ReportContext report = PepeniumReportCollector.collect(
+                "dashboardFlow",
+                new DriverSession(driver, request),
+                null,
+                reportDir
+        );
+
+        String html = PepeniumReportHtmlRenderer.render(report);
+
+        assertTrue(html.contains("<h2>Screenshots</h2>"));
+        assertTrue(html.contains("Screenshot 1"));
+        assertTrue(html.contains("Screenshot 2"));
+        assertTrue(html.contains("first-source.png"));
+        assertTrue(html.contains("second-source.png"));
+    }
 }


### PR DESCRIPTION
## Summary
- resolve local desktop web capability overrides from Java system properties before environment variables
- keep the existing `PEPENIUM_WEB_*` env-var names while also supporting property-style keys such as `pepenium.web.headless`
- cover headless Chrome resolution from `-Dpepenium.web.headless=true`

## Validation
- `mvn -B -ntp -pl pepenium-core "-Dtest=WebCapabilityOverridesTest" test`
- `mvn -q -DskipTests test-compile`
