### PR TITLE
[codex] Prepare release 0.9.8

### DIFF
--- a/.github/scripts/Test-ReleasePreflight.ps1
+++ b/.github/scripts/Test-ReleasePreflight.ps1
@@ -50,17 +50,18 @@ if (-not $releaseHeading) {
 
 $null = $releaseHeading -match $changelogPattern
 $releaseDate = [DateTime]::ParseExact($Matches[1], "yyyy-MM-dd", [Globalization.CultureInfo]::InvariantCulture)
-$outputTimestampValue = $pom.project.properties.'project.build.outputTimestamp'
+$outputTimestampValue = [string]$pom.project.properties.'project.build.outputTimestamp'
 if ([string]::IsNullOrWhiteSpace($outputTimestampValue)) {
     throw "pom.xml must define project.build.outputTimestamp for reproducible release artifacts."
 }
 try {
-    $outputTimestamp = [DateTimeOffset]::Parse($outputTimestampValue, [Globalization.CultureInfo]::InvariantCulture)
+    $outputTimestamp = [DateTime]::Parse($outputTimestampValue, [Globalization.CultureInfo]::InvariantCulture)
 } catch {
     throw "project.build.outputTimestamp '$outputTimestampValue' must be a valid ISO-8601 timestamp."
 }
-if ($outputTimestamp.UtcDateTime.Date -ne $releaseDate.Date) {
-    throw "project.build.outputTimestamp date '$($outputTimestamp.UtcDateTime.ToString('yyyy-MM-dd'))' must match changelog release date '$($releaseDate.ToString('yyyy-MM-dd'))'."
+$outputTimestampUtc = $outputTimestamp.ToUniversalTime()
+if ($outputTimestampUtc.Date -ne $releaseDate.Date) {
+    throw "project.build.outputTimestamp date '$($outputTimestampUtc.ToString('yyyy-MM-dd'))' must match changelog release date '$($releaseDate.ToString('yyyy-MM-dd'))'."
 }
 
 if (-not ($changelogLines | Where-Object { $_ -eq "## [Unreleased]" })) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.8] - 2026-06-22
+
 ### Added
 - Added an immutable structured-settings API with recursive global/profile merging for complex private-provider configuration.
 - Added open-ended global and per-profile YAML `settings` for private providers and custom driver configurations without weakening validation of built-in options.
@@ -67,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Made BrowserStack YAML path resolution trim accidental whitespace while rejecting null or blank paths with clearer messages.
 
 ### Fixed
+- Made release timestamp validation work consistently in Windows PowerShell by parsing the POM value as text.
 - Prevented authenticated provider URLs, nested capability secrets and credential-bearing exception messages or stack traces from leaking into banners, logs or generated reports.
 - Kept built-in execution-profile contract checks independent from consumer profiles discovered through `ServiceLoader`, with explicit `builtInList()` introspection.
 - Added early validation for consumer-provided execution profile metadata, duplicate IDs, provider failures and null lazy configs.

--- a/README.es.md
+++ b/README.es.md
@@ -90,7 +90,7 @@ Dependencia tipica de consumo:
 <dependency>
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-toolkit</artifactId>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Typical consumer dependency:
 <dependency>
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-toolkit</artifactId>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/consumer-smoke/pom.xml
+++ b/consumer-smoke/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <pepenium.version>0.9.7</pepenium.version>
+        <pepenium.version>0.9.8</pepenium.version>
         <junit.jupiter.version>5.13.1</junit.jupiter.version>
     </properties>
 

--- a/pepenium-core/pom.xml
+++ b/pepenium-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.8</version>
     </parent>
 
     <artifactId>pepenium</artifactId>

--- a/pepenium-examples/pom.xml
+++ b/pepenium-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.8</version>
     </parent>
 
     <artifactId>pepenium-examples</artifactId>

--- a/pepenium-maven-plugin/pom.xml
+++ b/pepenium-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.8</version>
     </parent>
 
     <artifactId>pepenium-maven-plugin</artifactId>

--- a/pepenium-toolkit/pom.xml
+++ b/pepenium-toolkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.roberto22palomar</groupId>
         <artifactId>pepenium-parent</artifactId>
-        <version>0.9.7</version>
+        <version>0.9.8</version>
     </parent>
 
     <artifactId>pepenium-toolkit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.roberto22palomar</groupId>
     <artifactId>pepenium-parent</artifactId>
-    <version>0.9.7</version>
+    <version>0.9.8</version>
     <packaging>pom</packaging>
     <name>Pepenium</name>
     <description>Java automation framework for Android, iOS and Web built on Appium, Selenium and JUnit 5.</description>
@@ -44,7 +44,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>2026-04-07T00:00:00Z</project.build.outputTimestamp>
+        <project.build.outputTimestamp>2026-06-22T00:00:00Z</project.build.outputTimestamp>
         <maven.compiler.release>11</maven.compiler.release>
 
         <selenium.bom.version>4.39.0</selenium.bom.version>


### PR DESCRIPTION
## Summary

- promote the current `Unreleased` changelog entries to `0.9.8` dated 2026-06-22
- update parent, module, consumer-smoke and README versions to `0.9.8`
- align `project.build.outputTimestamp` with the release date
- make release timestamp validation compatible with Windows PowerShell while retaining CI behavior

## Scope

This branch is based directly on the latest public `origin/main` (`2648d8d`). It does not include the PDF reporting PR #139, which has not been merged into `main`.

## Validation

- `./.github/scripts/Test-ReleasePreflight.ps1 -ReleaseVersion 0.9.8`
- release-profile packaging previously validated successfully on JDK 17 with sources and Javadocs attached

## Publication follow-up

After this PR is merged and CI is green, tag the immutable merge commit as `v0.9.8` to trigger the Maven Central publication workflow.